### PR TITLE
Change shebang to use environment python

### DIFF
--- a/spotdl.py
+++ b/spotdl.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 from bs4 import BeautifulSoup
 import spotipy


### PR DESCRIPTION
Invoke python with env(1) to use the environment python rather than the system python.

This is a super small and simple quality of life thing. `env` is standard on just about every system, and causes the local environment to be searched for an interpreter rather than using a path directly. On a Mac, for instance, there is no /bin/python.