### PR TITLE
Improved conversion with ffmpeg

### DIFF
--- a/spotdl.py
+++ b/spotdl.py
@@ -124,14 +124,14 @@ def generateFileName(content):
 
 def downloadSong(content):
     music_file = generateFileName(content)
-    if args.input_ext == '.webm':
+    if input_ext == '.webm':
         link = content.getbestaudio(preftype='webm')
         if link is not None:
-            link.download(filepath='Music/' + music_file + args.input_ext)
+            link.download(filepath='Music/' + music_file + input_ext)
     else:
         link = content.getbestaudio(preftype="m4a")
         if link is not None:
-            link.download(filepath="Music/" + music_file + ".m4a")
+            link.download(filepath='Music/' + music_file + input_ext)
 
 
 def convertToMP3(music_file):
@@ -156,32 +156,58 @@ def convertToMP3(music_file):
     os.remove('Music/' + music_file + '.m4a')
 
 
-def convertToM4A(music_file):
-    # Here we prefer downloading .webm (Opus) audio and encode as m4a
-    # in format prefered by iTunes - AAC (256k)
-    # We are using ffmpeg with fdk_aac code and cutoff at 18kHz
-    # python3 spotdl.py -i '.webm' -o '.m4a'
+def convertWithFfmpeg(music_file):
+    # What are the differences and similarities between ffmpeg, libav, and avconv?
+    # https://stackoverflow.com/questions/9477115
+    # ffmeg encoders high to lower quality
+    # libopus > libvorbis >= libfdk_aac > aac > libmp3lame
+    # libfdk_aac due to copyrights needs to be compiled by end user
+    # on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
+    # https://trac.ffmpeg.org/wiki/Encode/AAC
+    #
+    print('convertWithFfmpeg()', input_ext, output_ext)
     if args.quiet:
         ffmpeg_pre = 'ffmpeg -hide_banner -nostats -v panic -y '
     else:
         ffmpeg_pre = 'ffmpeg -y '
-    os.system(ffmpeg_pre +
-              '-i "Music/' + music_file + args.input_ext + '" ' +
-              '-cutoff 18000 -c:a libfdk_aac -b:a 256k -vn ' +
-              '"Music/_' + music_file + args.output_ext + '" ')
 
-    os.remove('Music/' + music_file + args.input_ext)
+    if input_ext == '.m4a':
+        if output_ext == '.mp3':
+            ffmpeg_params = '-codec:v copy -codec:a libmp3lame -q:a 2 '
+        elif output_ext == '.webm':
+            ffmpeg_params = '-c:a libopus -vbr on -b:a 192k -vn '
+        else:
+            return
+    elif input_ext == '.webm':
+        if output_ext == '.mp3':
+            ffmpeg_params = '-ab 192k -ar 44100 -vn '
+        elif output_ext == '.m4a':
+            ffmpeg_params = '-cutoff 20000 -c:a libfdk_aac -b:a 256k -vn '
+        else:
+            return
+    else:
+        print('Unknown formats. Unable to convert.', input_ext, output_ext)
+        return
+    if not args.quiet:
+        print(ffmpeg_pre +
+              '-i "Music/' + music_file + input_ext + '" ' +
+              ffmpeg_params +
+              '"Music/' + music_file + output_ext + '" ')
+        os.system(ffmpeg_pre +
+                  '-i "Music/' + music_file + input_ext + '" ' +
+                  ffmpeg_params +
+                  '"Music/' + music_file + output_ext + '" ')
+
+        os.remove('Music/' + music_file + input_ext)
 
 
 def checkExists(music_file, raw_song, islist):
-    if os.path.exists("Music/" + music_file + ".m4a.temp"):
-        os.remove("Music/" + music_file + ".m4a.temp")
+    if os.path.exists("Music/" + music_file + input_ext + ".temp"):
+        os.remove("Music/" + music_file + input_ext + ".temp")
     if args.no_convert:
-        extension = args.input_ext
+        extension = input_ext
     else:
-        if os.path.exists('Music/' + music_file + args.input_ext):
-            os.remove('Music/' + music_file + args.input_ext)
-        extension = args.output_ext
+        extension = output_ext
     if os.path.isfile("Music/" + music_file + extension):
         if extension == '.mp3':
             audiofile = eyed3.load("Music/" + music_file + extension)
@@ -248,7 +274,7 @@ def fixSongM4A(music_file, meta_tags):
             'disk': 'disk',
             'cpil': 'cpil',
             'tempo': 'tmpo'}
-    audiofile = MP4('Music/_' + music_file + args.output_ext)
+    audiofile = MP4('Music/_' + music_file + output_ext)
     audiofile[tags['artist']] = meta_tags['artists'][0]['name']
     audiofile[tags['album']] = meta_tags['album']['name']
     audiofile[tags['title']] = meta_tags['name']
@@ -287,15 +313,16 @@ def grabSingle(raw_song, number=None):
         print('')
         if not args.no_convert:
             print('Converting ' + music_file + '.m4a to mp3')
-            if args.output_ext == '.m4a':
-                convertToM4A(music_file)
-                meta_tags = generateMetaTags(raw_song)
+            if args.ffmpeg:
+                convertWithFfmpeg(music_file)
+            else:
+                convertToMP3(music_file)
+            meta_tags = generateMetaTags(raw_song)
+            if output_ext == '.m4a':
                 if meta_tags is not None:
                     print('Fixing meta-tags')
                     fixSongM4A(music_file, meta_tags)
-            else:
-                convertToMP3(music_file)
-                meta_tags = generateMetaTags(raw_song)
+            elif output_ext == '.mp3':
                 if meta_tags is not None:
                     print('Fixing meta-tags')
                     fixSong(music_file, meta_tags)
@@ -348,6 +375,9 @@ def getArgs(argv=None):
                         help='choose the song to download manually', action='store_true')
     parser.add_argument('-l', '--list', default=False,
                         help='download songs present in list.txt', action='store_true')
+    parser.add_argument('-f', '--ffmpeg', default=False,
+                        help='Use ffmpeg instead of libav for conversion. If not set defaults to libav',
+                        action='store_true')
     parser.add_argument('-q', '--quiet', default=False,
                         help='spare us output of ffmpeg conversion', action='store_true')
     parser.add_argument('-i', '--input_ext', default='.m4a',
@@ -387,7 +417,12 @@ if __name__ == '__main__':
 
     # Set up arguments
     args = getArgs()
-
+    if args.ffmpeg:
+        input_ext = args.input_ext
+        output_ext = args.output_ext
+    else:
+        input_ext = '.m4a'
+        output_ext = '.mp3'
     if args.no_convert:
         print("-n, --no-convert skip the conversion process and meta-tags")
     if args.manual:

--- a/spotdl.py
+++ b/spotdl.py
@@ -445,7 +445,6 @@ if __name__ == '__main__':
     if args.list:
         grabList(file='list.txt')
         exit()
-    if args.quiet:
-        eyed3.log.setLevel("ERROR")
+    eyed3.log.setLevel("ERROR")
 
     spotifyDownload()

--- a/spotdl.py
+++ b/spotdl.py
@@ -191,15 +191,13 @@ def convertWithFfmpeg(music_file):
               '-i "Music/' + music_file + input_ext + '" ' +
               ffmpeg_params +
               '"Music/' + music_file + output_ext + '" ')
-    try:
-        os.system(ffmpeg_pre +
-                  '-i "Music/' + music_file + input_ext + '" ' +
-                  ffmpeg_params +
-                  '"Music/' + music_file + output_ext + '" ')
 
-        os.remove('Music/' + music_file + input_ext)
-    except Exception as e:
-        raise
+    os.system(
+        ffmpeg_pre +
+        '-i "Music/' + music_file + input_ext + '" ' +
+        ffmpeg_params +
+        '"Music/' + music_file + output_ext + '" ')
+    os.remove('Music/' + music_file + input_ext)
 
 
 def checkExists(music_file, raw_song, islist):
@@ -425,11 +423,9 @@ if __name__ == '__main__':
     open('list.txt', 'a').close()
 
     # Please respect this user token :)
-    # oauth2 = oauth2.SpotifyClientCredentials(client_id='4fe3fecfe5334023a1472516cc99d805',
-    #                                          client_secret='0f02b7c483c04257984695007a4a8d5c')
     oauth2 = oauth2.SpotifyClientCredentials(
-        client_id='768998a7e3444c6a82f0c11ddd59c946',
-        client_secret='4b1e7672e14a42269ee4a22e11214fdf')
+        client_id='4fe3fecfe5334023a1472516cc99d805',
+        client_secret='0f02b7c483c04257984695007a4a8d5c')
     token = oauth2.get_access_token()
     spotify = spotipy.Spotify(auth=token)
 

--- a/spotdl.py
+++ b/spotdl.py
@@ -165,7 +165,6 @@ def convertWithFfmpeg(music_file):
     # on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
     # https://trac.ffmpeg.org/wiki/Encode/AAC
     #
-    print('convertWithFfmpeg()', input_ext, output_ext)
     if args.quiet:
         ffmpeg_pre = 'ffmpeg -hide_banner -nostats -v panic -y '
     else:
@@ -274,7 +273,7 @@ def fixSongM4A(music_file, meta_tags):
             'disk': 'disk',
             'cpil': 'cpil',
             'tempo': 'tmpo'}
-    audiofile = MP4('Music/_' + music_file + output_ext)
+    audiofile = MP4('Music/' + music_file + output_ext)
     audiofile[tags['artist']] = meta_tags['artists'][0]['name']
     audiofile[tags['album']] = meta_tags['album']['name']
     audiofile[tags['title']] = meta_tags['name']
@@ -312,7 +311,7 @@ def grabSingle(raw_song, number=None):
         downloadSong(content)
         print('')
         if not args.no_convert:
-            print('Converting ' + music_file + '.m4a to mp3')
+            print('Converting ' + music_file + input_ext + ' to ' + output_ext)
             if args.ffmpeg:
                 convertWithFfmpeg(music_file)
             else:


### PR DESCRIPTION
Hello,

I have rewritten the code slightly. It is now `convertWithFfmpeg()` function in place of `convertToM4A()` - more robust and flexible. Before user could be tricked into thinking that all kind of formats could be converted into each other but the function handled only webm to m4a. Now it handles all cases (but m4a to m4a and webm to webm simply skips conversion quietly).

I understand that obtaining ffmpeg with libfdk_aac and libopus could be a pain for some people, especially on linux. Hence default sticks to libav.

There is new parameter `-f --fmpeg`. 

* If called without parameter spotdl.py is using libav and `convertToMP3()` so no change for the user. 

* If called with `-f or --fmpeg` it is using `convertWithFfmpeg()` and taking `--input_ext and --output_ext` parameters.

So now user can convert webm to mp3 or m4a using ffmepg and m4a to mp3, webm.

The rest is just better handling of filenames and extensions.

PS. ffmpeg could also handle writing metadata and cover art. I will play with the idea and perhaps we could replace mutagen and eyed3?