### PR TITLE
Fix playlist name encode

### DIFF
--- a/spotdl.py
+++ b/spotdl.py
@@ -130,7 +130,7 @@ def feedPlaylist(username):
     links = []
     check = 1
     for playlist in playlists['items']:
-        print(str(check) + '. ' + playlist['name'] + ' (' + str(playlist['tracks']['total']) + ' tracks)')
+        print(str(check) + '. ' + playlist['name'].encode('utf-8') + ' (' + str(playlist['tracks']['total']) + ' tracks)')
         links.append(playlist)
         check += 1
     print('')


### PR DESCRIPTION
Fixes this error:

    Traceback (most recent call last):
      File "spotdl.py", line 495, in <module>
        feedPlaylist(username=args.username)
      File "spotdl.py", line 133, in feedPlaylist
        print(str(check) + '. ' + playlist['name'] + ' (' + str(playlist['tracks']['total']) + ' tracks)')
    UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 11: ordinal not in range(128)

test username: officialthesoundyouneed
