### PR TITLE
Clean up code to match PEP8

### DIFF
--- a/core/convert.py
+++ b/core/convert.py
@@ -77,7 +77,7 @@ def convert_with_ffmpeg(input_song, output_song, verbose):
         elif output_ext == 'm4a':
             ffmpeg_params = '-cutoff 20000 -c:a libfdk_aac -b:a 192k -vn '
 
-    command = '{0}-i Music/{1} {2}Music/{4}'.format(
+    command = '{0}-i Music/{1} {2}Music/{3}'.format(
         ffmpeg_pre, input_song, ffmpeg_params, output_song).split(' ')
 
     return subprocess.call(command)

--- a/core/convert.py
+++ b/core/convert.py
@@ -4,11 +4,13 @@ import sys
 
 
 def song(input_song, output_song, avconv=False, verbose=False):
+    """Do the audio format conversion."""
     if not input_song == output_song:
         if sys.version_info < (3, 0):
             input_song = input_song.encode('utf-8')
             output_song = output_song.encode('utf-8')
-        print('Converting ' + input_song + ' to ' + output_song.split('.')[-1])
+        print('Converting {0} to {1}'.format(
+            input_song, output_song.split('.')[-1]))
         if avconv:
             exit_code = convert_with_avconv(input_song, output_song, verbose)
         else:
@@ -18,7 +20,7 @@ def song(input_song, output_song, avconv=False, verbose=False):
 
 
 def convert_with_avconv(input_song, output_song, verbose):
-    # different path for windows
+    """Convert the audio file using avconv."""
     if os.name == 'nt':
         avconv_path = 'Scripts\\avconv.exe'
     else:
@@ -39,13 +41,16 @@ def convert_with_avconv(input_song, output_song, verbose):
 
 
 def convert_with_ffmpeg(input_song, output_song, verbose):
-    # What are the differences and similarities between ffmpeg, libav, and avconv?
-    # https://stackoverflow.com/questions/9477115
-    # ffmeg encoders high to lower quality
-    # libopus > libvorbis >= libfdk_aac > aac > libmp3lame
-    # libfdk_aac due to copyrights needs to be compiled by end user
-    # on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
-    # https://trac.ffmpeg.org/wiki/Encode/AAC
+    """Convert the audio file using FFMpeg.
+
+    What are the differences and similarities between ffmpeg, libav, and avconv?
+    https://stackoverflow.com/questions/9477115
+    ffmeg encoders high to lower quality
+    libopus > libvorbis >= libfdk_aac > aac > libmp3lame
+    libfdk_aac due to copyrights needs to be compiled by end user
+    on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
+    https://trac.ffmpeg.org/wiki/Encode/AAC
+    """
 
     if os.name == "nt":
         ffmpeg_pre = 'Scripts\\ffmpeg.exe '

--- a/core/convert.py
+++ b/core/convert.py
@@ -2,6 +2,7 @@ import subprocess
 import os
 import sys
 
+
 def song(input_song, output_song, avconv=False, verbose=False):
     if not input_song == output_song:
         if sys.version_info < (3, 0):
@@ -11,9 +12,10 @@ def song(input_song, output_song, avconv=False, verbose=False):
         if avconv:
             exit_code = convert_with_avconv(input_song, output_song, verbose)
         else:
-            exit_code = convert_with_FFmpeg(input_song, output_song, verbose)
+            exit_code = convert_with_ffmpeg(input_song, output_song, verbose)
         return exit_code
     return None
+
 
 def convert_with_avconv(input_song, output_song, verbose):
     # different path for windows
@@ -33,10 +35,10 @@ def convert_with_avconv(input_song, output_song, verbose):
                '-ab',       '192k',
                'Music/' + output_song]
 
-    subprocess.call(command)
+    return subprocess.call(command)
 
 
-def convert_with_FFmpeg(input_song, output_song, verbose):
+def convert_with_ffmpeg(input_song, output_song, verbose):
     # What are the differences and similarities between ffmpeg, libav, and avconv?
     # https://stackoverflow.com/questions/9477115
     # ffmeg encoders high to lower quality
@@ -54,6 +56,7 @@ def convert_with_FFmpeg(input_song, output_song, verbose):
     if not verbose:
         ffmpeg_pre += '-hide_banner -nostats -v panic '
 
+    ffmpeg_params = ''
     input_ext = input_song.split('.')[-1]
     output_ext = output_song.split('.')[-1]
 
@@ -69,10 +72,8 @@ def convert_with_FFmpeg(input_song, output_song, verbose):
         elif output_ext == 'm4a':
             ffmpeg_params = '-cutoff 20000 -c:a libfdk_aac -b:a 192k -vn '
 
-    command = (ffmpeg_pre +
-              '-i Music/' + input_song + ' ' +
-               ffmpeg_params +
-              'Music/' + output_song + '').split(' ')
+    command = '{0}-i Music/{1} {2}Music/{4}'.format(
+        ffmpeg_pre, input_song, ffmpeg_params, output_song).split(' ')
 
-    subprocess.call(command)
+    return subprocess.call(command)
 

--- a/core/metadata.py
+++ b/core/metadata.py
@@ -10,8 +10,8 @@ except ImportError:
     import urllib.request as urllib2
 
 
-# check if input file title matches with expected title
 def compare(file, metadata):
+    """Check if the input file title matches the expected title."""
     already_tagged = False
     try:
         if file.endswith('.mp3'):
@@ -29,6 +29,7 @@ def compare(file, metadata):
 
 
 def embed(music_file, meta_tags):
+    """Embed metadata."""
     if sys.version_info < (3, 0):
         music_file = music_file.encode('utf-8')
     if meta_tags is None:
@@ -46,6 +47,7 @@ def embed(music_file, meta_tags):
 
 
 def embed_mp3(music_file, meta_tags):
+    """Embed metadata to MP3 files."""
     # EasyID3 is fun to use ;)
     audiofile = EasyID3('Music/' + music_file)
     audiofile['artist'] = meta_tags['artists'][0]['name']
@@ -81,6 +83,7 @@ def embed_mp3(music_file, meta_tags):
 
 
 def embed_m4a(music_file, meta_tags):
+    """Embed metadata to M4A files."""
     # Apple has specific tags - see mutagen docs -
     # http://mutagen.readthedocs.io/en/latest/api/mp4.html
     tags = {'album': '\xa9alb',

--- a/core/metadata.py
+++ b/core/metadata.py
@@ -9,8 +9,10 @@ try:
 except ImportError:
     import urllib.request as urllib2
 
+
 # check if input file title matches with expected title
 def compare(file, metadata):
+    already_tagged = False
     try:
         if file.endswith('.mp3'):
             audiofile = EasyID3('Music/' + file)
@@ -22,8 +24,9 @@ def compare(file, metadata):
             # fetch track title metadata
             already_tagged = audiofile[tags['title']] == metadata['name']
     except KeyError:
-            already_tagged = False
+        pass
     return already_tagged
+
 
 def embed(music_file, meta_tags):
     if sys.version_info < (3, 0):
@@ -41,6 +44,7 @@ def embed(music_file, meta_tags):
         print('Cannot embed meta-tags into given output extension')
         return False
 
+
 def embed_mp3(music_file, meta_tags):
     # EasyID3 is fun to use ;)
     audiofile = EasyID3('Music/' + music_file)
@@ -48,7 +52,8 @@ def embed_mp3(music_file, meta_tags):
     audiofile['albumartist'] = meta_tags['artists'][0]['name']
     audiofile['album'] = meta_tags['album']['name']
     audiofile['title'] = meta_tags['name']
-    audiofile['tracknumber'] = [meta_tags['track_number'], meta_tags['total_tracks']]
+    audiofile['tracknumber'] = [meta_tags['track_number'],
+                                meta_tags['total_tracks']]
     audiofile['discnumber'] = [meta_tags['disc_number'], 0]
     audiofile['date'] = meta_tags['release_date']
     audiofile['originaldate'] = meta_tags['release_date']
@@ -68,10 +73,12 @@ def embed_mp3(music_file, meta_tags):
     audiofile.save(v2_version=3)
     audiofile = ID3('Music/' + music_file)
     albumart = urllib2.urlopen(meta_tags['album']['images'][0]['url'])
-    audiofile["APIC"] = APIC(encoding=3, mime='image/jpeg', type=3, desc=u'Cover', data=albumart.read())
+    audiofile["APIC"] = APIC(encoding=3, mime='image/jpeg', type=3,
+                             desc=u'Cover', data=albumart.read())
     albumart.close()
     audiofile.save(v2_version=3)
     return True
+
 
 def embed_m4a(music_file, meta_tags):
     # Apple has specific tags - see mutagen docs -
@@ -98,7 +105,8 @@ def embed_m4a(music_file, meta_tags):
     audiofile[tags['albumartist']] = meta_tags['artists'][0]['name']
     audiofile[tags['album']] = meta_tags['album']['name']
     audiofile[tags['title']] = meta_tags['name']
-    audiofile[tags['tracknumber']] = [(meta_tags['track_number'], meta_tags['total_tracks'])]
+    audiofile[tags['tracknumber']] = [(meta_tags['track_number'],
+                                       meta_tags['total_tracks'])]
     audiofile[tags['disknumber']] = [(meta_tags['disc_number'], 0)]
     audiofile[tags['date']] = meta_tags['release_date']
     audiofile[tags['originaldate']] = meta_tags['release_date']
@@ -107,7 +115,8 @@ def embed_m4a(music_file, meta_tags):
     if meta_tags['copyright']:
         audiofile[tags['copyright']] = meta_tags['copyright']
     albumart = urllib2.urlopen(meta_tags['album']['images'][0]['url'])
-    audiofile[tags['albumart']] = [ MP4Cover(albumart.read(), imageformat=MP4Cover.FORMAT_JPEG) ]
+    audiofile[tags['albumart']] = [MP4Cover(
+        albumart.read(), imageformat=MP4Cover.FORMAT_JPEG)]
     albumart.close()
     audiofile.save()
     return True

--- a/core/misc.py
+++ b/core/misc.py
@@ -6,15 +6,16 @@ import spotipy.oauth2 as oauth2
 
 try:
     from urllib2 import quote
-except:
+except ImportError:
     from urllib.request import quote
+
 
 # method to input (user playlists) and (track when using manual mode)
 def input_link(links):
     while True:
         try:
             the_chosen_one = int(user_input('>> Choose your number: '))
-            if the_chosen_one >= 1 and the_chosen_one <= len(links):
+            if 1 <= the_chosen_one <= len(links):
                 return links[the_chosen_one - 1]
             elif the_chosen_one == 0:
                 return None
@@ -23,6 +24,7 @@ def input_link(links):
         except ValueError:
             print('Choose a valid number!')
 
+
 # take input correctly for both python2 & 3
 def user_input(string=''):
     if sys.version_info > (3, 0):
@@ -30,40 +32,50 @@ def user_input(string=''):
     else:
         return raw_input(string)
 
+
 # remove first song from .txt
 def trim_song(file):
-    with open(file, 'r') as fin:
-        data = fin.read().splitlines(True)
-    with open(file, 'w') as fout:
-        fout.writelines(data[1:])
+    with open(file, 'r') as file_in:
+        data = file_in.read().splitlines(True)
+    with open(file, 'w') as file_out:
+        file_out.writelines(data[1:])
+
 
 def get_arguments():
-    parser = argparse.ArgumentParser(description='Download and convert songs \
-                    from Spotify, Youtube etc.',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description='Download and convert songs from Spotify, Youtube etc.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     group = parser.add_mutually_exclusive_group(required=True)
 
-    group.add_argument('-s', '--song',
-                        help='download song by spotify link or name')
-    group.add_argument('-l', '--list',
-                        help='download songs from a file')
-    group.add_argument('-u', '--username',
-                        help="load user's playlists into <playlist_name>.txt")
-    parser.add_argument('-m', '--manual', default=False,
-                        help='choose the song to download manually', action='store_true')
-    parser.add_argument('-nm', '--no-metadata', default=False,
-                        help='do not embed metadata in songs', action='store_true')
-    parser.add_argument('-a', '--avconv', default=False,
-                        help='Use avconv for conversion otherwise set defaults to ffmpeg',
-                        action='store_true')
-    parser.add_argument('-v', '--verbose', default=False,
-                        help='show debug output', action='store_true')
-    parser.add_argument('-i', '--input_ext', default='.m4a',
-                        help='prefered input format .m4a or .webm (Opus)')
-    parser.add_argument('-o', '--output_ext', default='.mp3',
-                        help='prefered output extension .mp3 or .m4a (AAC)')
+    group.add_argument(
+        '-s', '--song', help='download song by spotify link or name')
+    group.add_argument(
+        '-l', '--list', help='download songs from a file')
+    group.add_argument(
+        '-u', '--username',
+        help="load user's playlists into <playlist_name>.txt")
+    parser.add_argument(
+        '-m', '--manual', default=False,
+        help='choose the song to download manually', action='store_true')
+    parser.add_argument(
+        '-nm', '--no-metadata', default=False,
+        help='do not embed metadata in songs', action='store_true')
+    parser.add_argument(
+        '-a', '--avconv', default=False,
+        help='Use avconv for conversion otherwise set defaults to ffmpeg',
+        action='store_true')
+    parser.add_argument(
+        '-v', '--verbose', default=False, help='show debug output',
+        action='store_true')
+    parser.add_argument(
+        '-i', '--input_ext', default='.m4a',
+        help='prefered input format .m4a or .webm (Opus)')
+    parser.add_argument(
+        '-o', '--output_ext', default='.mp3',
+        help='prefered output extension .mp3 or .m4a (AAC)')
 
     return parser.parse_args()
+
 
 # check if input song is spotify link
 def is_spotify(raw_song):
@@ -71,6 +83,7 @@ def is_spotify(raw_song):
         return True
     else:
         return False
+
 
 # generate filename of the song to be downloaded
 def generate_filename(title):
@@ -82,18 +95,22 @@ def generate_filename(title):
     filename = slugify(title, ok='-_()[]{}', lower=False)
     return fix_encoding(filename)
 
+
 # please respect these credentials :)
 def generate_token():
-    creds = oauth2.SpotifyClientCredentials(
+    credentials = oauth2.SpotifyClientCredentials(
         client_id='4fe3fecfe5334023a1472516cc99d805',
         client_secret='0f02b7c483c04257984695007a4a8d5c')
-    token = creds.get_access_token()
+    token = credentials.get_access_token()
     return token
+
 
 def generate_search_url(song):
     # urllib2.quote() encodes URL with special characters
-    url = "https://www.youtube.com/results?sp=EgIQAQ%253D%253D&q=" + quote(song)
+    url = "https://www.youtube.com/results?sp=EgIQAQ%253D%253D&q={0}".format(
+        quote(song))
     return url
+
 
 # fix encoding issues in python2
 def fix_encoding(query):
@@ -101,10 +118,12 @@ def fix_encoding(query):
         query = query.encode('utf-8')
     return query
 
+
 def fix_decoding(query):
     if sys.version_info < (3, 0):
         query = query.decode('utf-8')
     return query
+
 
 def filter_path(path):
     os.chdir(sys.path[0])
@@ -112,10 +131,9 @@ def filter_path(path):
         os.makedirs(path)
     for temp in os.listdir(path):
         if temp.endswith('.temp'):
-            os.remove(path + '/' + temp)
+            os.remove('{0}/{1}'.format(path, temp))
+
 
 def grace_quit():
-    print('')
-    print('')
-    print('Exitting..')
+    print('\n\nExiting.')
     sys.exit()

--- a/core/misc.py
+++ b/core/misc.py
@@ -10,8 +10,8 @@ except ImportError:
     from urllib.request import quote
 
 
-# method to input (user playlists) and (track when using manual mode)
 def input_link(links):
+    """Let the user input a number."""
     while True:
         try:
             the_chosen_one = int(user_input('>> Choose your number: '))
@@ -25,16 +25,16 @@ def input_link(links):
             print('Choose a valid number!')
 
 
-# take input correctly for both python2 & 3
 def user_input(string=''):
+    """Take input correctly for both Python 2 & 3."""
     if sys.version_info > (3, 0):
         return input(string)
     else:
         return raw_input(string)
 
 
-# remove first song from .txt
 def trim_song(file):
+    """Remove the first song from file."""
     with open(file, 'r') as file_in:
         data = file_in.read().splitlines(True)
     with open(file, 'w') as file_out:
@@ -77,27 +77,29 @@ def get_arguments():
     return parser.parse_args()
 
 
-# check if input song is spotify link
 def is_spotify(raw_song):
-    if (len(raw_song) == 22 and raw_song.replace(" ", "%20") == raw_song) or (raw_song.find('spotify') > -1):
+    """Check if the input song is a Spotify link."""
+    if (len(raw_song) == 22 and raw_song.replace(" ", "%20") == raw_song) or \
+            (raw_song.find('spotify') > -1):
         return True
     else:
         return False
 
 
-# generate filename of the song to be downloaded
 def generate_filename(title):
+    """Generate filename of the song to be downloaded."""
     # IMO python2 sucks dealing with unicode
     title = fix_encoding(title)
     title = fix_decoding(title)
     title = title.replace(' ', '_')
+
     # slugify removes any special characters
     filename = slugify(title, ok='-_()[]{}', lower=False)
     return fix_encoding(filename)
 
 
-# please respect these credentials :)
 def generate_token():
+    """Generate the token. Please respect these credentials :)"""
     credentials = oauth2.SpotifyClientCredentials(
         client_id='4fe3fecfe5334023a1472516cc99d805',
         client_secret='0f02b7c483c04257984695007a4a8d5c')
@@ -106,20 +108,22 @@ def generate_token():
 
 
 def generate_search_url(song):
+    """Generate YouTube search URL for the given song."""
     # urllib2.quote() encodes URL with special characters
     url = "https://www.youtube.com/results?sp=EgIQAQ%253D%253D&q={0}".format(
         quote(song))
     return url
 
 
-# fix encoding issues in python2
 def fix_encoding(query):
+    """Fix encoding issues in Python 2."""
     if sys.version_info < (3, 0):
         query = query.encode('utf-8')
     return query
 
 
 def fix_decoding(query):
+    """Fix decoding issues in Python 2."""
     if sys.version_info < (3, 0):
         query = query.decode('utf-8')
     return query

--- a/spotdl.py
+++ b/spotdl.py
@@ -115,7 +115,7 @@ def get_youtube_title(content, number=None):
     if number is None:
         return title
     else:
-        return u'{0}. {1}'.format(number, title)
+        return '{0}. {1}'.format(number, title)
 
 
 def feed_playlist(username):

--- a/spotdl.py
+++ b/spotdl.py
@@ -75,7 +75,7 @@ def generate_youtube_url(raw_song):
         # fetch all video links on first page on YouTube
         for x in items_parse.find_all('h3', {'class': 'yt-lockup-title'}):
             # confirm the video result is not an advertisement
-            if x.find('channel') > -1 or x.find('googleads') > -1:
+            if x.find('channel') is None and x.find('googleads') is None:
                 print('{0}. {1}'.format(check, x.get_text()))
                 links.append(x.find('a')['href'])
                 check += 1
@@ -130,8 +130,8 @@ def feed_playlist(username):
             # is None. Skip these. Also see Issue #91.
             if playlist['name'] is not None:
                 print('{0}. {1} ({2} tracks)'.format(
-                    check, misc.fix_encoding(playlist['name'])),
-                    playlist['tracks']['total'])
+                    check, misc.fix_encoding(playlist['name']),
+                    playlist['tracks']['total']))
                 links.append(playlist)
                 check += 1
         if playlists['next']:
@@ -283,7 +283,7 @@ def grab_single(raw_song, number=None):
             output_song = music_file + args.output_ext
             convert.song(input_song, output_song, avconv=args.avconv,
                          verbose=args.verbose)
-            os.remove('Music/{0}'.format(file))
+            os.remove('Music/{0}'.format(input_song))
             meta_tags = generate_metadata(raw_song)
             if not args.no_metadata:
                 metadata.embed(output_song, meta_tags)

--- a/spotdl.py
+++ b/spotdl.py
@@ -75,7 +75,7 @@ def generate_youtube_url(raw_song):
         # fetch all video links on first page on YouTube
         for x in items_parse.find_all('h3', {'class': 'yt-lockup-title'}):
             # confirm the video result is not an advertisement
-            if not x.find('channel') == -1 or not x.find('googleads') == -1:
+            if x.find('channel') > -1 or x.find('googleads') > -1:
                 print('{0}. {1}'.format(check, x.get_text()))
                 links.append(x.find('a')['href'])
                 check += 1
@@ -91,7 +91,7 @@ def generate_youtube_url(raw_song):
 
         # confirm the video result is not an advertisement
         # otherwise keep iterating until it is not
-        while result.find('channel') < 0 or result.find('googleads') < 0:
+        while result.find('channel') > -1 or result.find('googleads') > -1:
             result = items_parse.find_all(
                 attrs={'class': 'yt-uix-tile-link'})[check]['href']
             check += 1

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -4,21 +4,25 @@ import spotdl
 
 raw_song = 'http://open.spotify.com/track/0JlS7BXXD07hRmevDnbPDU'
 
+
 def test_spotify_title():
     expect_title = 'David André Østby - Intro'
     title = spotdl.generate_songname(raw_song)
     assert title == expect_title
+
 
 def test_youtube_url():
     expect_url = 'youtube.com/watch?v=rg1wfcty0BA'
     url = spotdl.generate_youtube_url(raw_song)
     assert url == expect_url
 
+
 def test_youtube_title():
     expect_title = 'Intro - David André Østby'
     content = spotdl.go_pafy(raw_song)
     title = spotdl.get_youtube_title(content)
     assert title == expect_title
+
 
 def test_check_exists():
     expect_check = False
@@ -28,11 +32,13 @@ def test_check_exists():
     check = spotdl.check_exists(music_file, raw_song)
     assert check == expect_check
 
+
 def test_download():
     expect_download = True
     content = spotdl.go_pafy(raw_song)
     download = spotdl.download_song(content)
     assert download == expect_download
+
 
 def test_convert():
     # exit code None = success
@@ -44,6 +50,7 @@ def test_convert():
     output_song = music_file + spotdl.args.output_ext
     convert = spotdl.convert.song(input_song, output_song)
     assert convert == expect_convert
+
 
 def test_metadata():
     expect_metadata = True
@@ -59,6 +66,7 @@ def test_metadata():
     metadata_input = spotdl.metadata.embed(input_song, meta_tags)
 
     assert metadata_output == (metadata_input == expect_metadata)
+
 
 def check_exists2():
     expect_check = True

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -41,8 +41,8 @@ def test_download():
 
 
 def test_convert():
-    # exit code None = success
-    expect_convert = None
+    # exit code 0 = success
+    expect_convert = 0
     content = spotdl.go_pafy(raw_song)
     music_file = spotdl.misc.generate_filename(content.title)
     music_file = spotdl.misc.fix_decoding(music_file)

--- a/test/test_username.py
+++ b/test/test_username.py
@@ -22,7 +22,8 @@ def test_playlist():
 def test_tracks():
     playlist = spotdl.spotify.user_playlists(username)['items'][0]
     expect_lines = playlist['tracks']['total']
-    result = spotdl.spotify.user_playlist(playlist['owner']['id'], playlist['id'], fields='tracks,next')
+    result = spotdl.spotify.user_playlist(
+        playlist['owner']['id'], playlist['id'], fields='tracks,next')
     tracks = result['tracks']
 
     with open('list.txt', 'a') as fout:

--- a/test/test_username.py
+++ b/test/test_username.py
@@ -4,17 +4,20 @@ import spotdl
 
 username = 'alex'
 
+
 def test_user():
     expect_playlists = 7
     playlists = spotdl.spotify.user_playlists(username)
     playlists = len(playlists['items'])
     assert playlists == expect_playlists
 
+
 def test_playlist():
     expect_tracks = 14
     playlist = spotdl.spotify.user_playlists(username)['items'][0]
     tracks = playlist['tracks']['total']
     assert tracks == expect_tracks
+
 
 def test_tracks():
     playlist = spotdl.spotify.user_playlists(username)['items'][0]


### PR DESCRIPTION
This will fix Issue #93 by applying PEP8's rules to most of the code. I'm sorry if this introduces a bug, if so, let me know immediately.

This refactoring includes:
- Have two empty lines before each global function
- Use `'{0} {1}'.format(str1, str2)` instead of `str1 + ' ' + str2`
  Sometimes this will make lines longer, sometimes shorter.
- Start all comments with `# + space + comment`, so `# space in front` not `#nospacehere`
- Make lines not longer than 80 characters in most cases (OK, 80-100 are fine)
- Rename some variables to make more sense
- Add some missing code like returns and Exceptions
- Transform comments above functions into docstrings
- Remove some way too verbose comments
- Fix some errors introduced with the first code cleanup
    
Not yet done, but IMHO not that important for now:
- Rename all 'file' variables, only for Python 2
- Add params to docstrings
- Use OOP/clases to avoid globals. IMHO the codebase is big enough.
