### PR TITLE
Change for automatical download video with this same duration as spotify song

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .cache/
 Music/
 *.txt
+.python-version

--- a/core/misc.py
+++ b/core/misc.py
@@ -141,3 +141,15 @@ def filter_path(path):
 def grace_quit():
     print('\n\nExiting.')
     sys.exit()
+    
+def get_sec(time_str):
+   v = time_str.split(':', 3)
+   v.reverse()
+   sec = 0
+   if len(v) > 0: #seconds
+       sec += int(v[0])
+   if len(v) > 1: # minutes
+       sec += int(v[1]) * 60
+   if len(v) > 2: # hours
+       sec += int(v[2]) * 3600
+   return sec

--- a/spotdl.py
+++ b/spotdl.py
@@ -299,7 +299,7 @@ def grab_single(raw_song, number=None):
 
     # generate file name of the song to download
     meta_tags = generate_metadata(raw_song)
-    songname = generate_songname(raw_song)
+    songname = generate_songname(meta_tags)
     file_name = misc.sanitize_title(songname)
 
     if not check_exists(file_name, raw_song, islist=islist):
@@ -311,7 +311,6 @@ def grab_single(raw_song, number=None):
                          avconv=args.avconv, verbose=args.verbose)
             if not args.input_ext == args.output_ext:
                 os.remove(os.path.join(args.folder, input_song))
-            meta_tags = generate_metadata(raw_song)
 
             if not args.no_metadata:
                 metadata.embed(os.path.join(args.folder, output_song), meta_tags)

--- a/spotdl.py
+++ b/spotdl.py
@@ -37,7 +37,7 @@ def generate_metadata(raw_song):
             return None
     artist = spotify.artist(meta_tags['artists'][0]['id'])
     album = spotify.album(meta_tags['album']['id'])
-    
+
     try:
         meta_tags[u'genre'] = titlecase(artist['genres'][0])
     except IndexError:
@@ -51,9 +51,6 @@ def generate_metadata(raw_song):
     meta_tags[u'publisher'] = album['label']
     meta_tags[u'total_tracks'] = album['tracks']['total']
 
-    #import pprint
-    #pprint.prpint(meta_tags)
-    # pprint.pprint(spotify.album(meta_tags['album']['id']))
     return meta_tags
 
 

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -11,7 +11,8 @@ for x in os.listdir(spotdl.args.folder):
 
 def test_spotify_title():
     expect_title = 'David André Østby - Intro'
-    title = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    title = spotdl.generate_songname(meta_tags)
     assert title == expect_title
 
 
@@ -25,14 +26,15 @@ def test_youtube_title():
     expect_title = 'Intro - David André Østby'
     content = spotdl.go_pafy(raw_song)
     title = spotdl.get_youtube_title(content)
+    print(title)
     assert title == expect_title
 
 
 def test_check_exists():
     expect_check = False
     # prerequisites for determining filename
-    content = spotdl.go_pafy(raw_song)
-    songname = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    songname = spotdl.generate_songname(meta_tags)
     file_name = spotdl.misc.sanitize_title(songname)
     check = spotdl.check_exists(file_name, raw_song, islist=True)
     assert check == expect_check
@@ -42,7 +44,8 @@ def test_download():
     expect_download = True
     # prerequisites for determining filename
     content = spotdl.go_pafy(raw_song)
-    songname = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    songname = spotdl.generate_songname(meta_tags)
     file_name = spotdl.misc.sanitize_title(songname)
     download = spotdl.download_song(file_name, content)
     assert download == expect_download
@@ -52,8 +55,8 @@ def test_convert():
     # exit code 0 = success
     expect_convert = 0
     # prerequisites for determining filename
-    content = spotdl.go_pafy(raw_song)
-    songname = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    songname = spotdl.generate_songname(meta_tags)
     file_name = spotdl.misc.sanitize_title(songname)
     input_song = file_name + spotdl.args.input_ext
     output_song = file_name + spotdl.args.output_ext
@@ -64,8 +67,8 @@ def test_convert():
 def test_metadata():
     expect_metadata = True
     # prerequisites for determining filename
-    content = spotdl.go_pafy(raw_song)
-    songname = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    songname = spotdl.generate_songname(meta_tags)
     meta_tags = spotdl.generate_metadata(raw_song)
     file_name = spotdl.misc.sanitize_title(songname)
     output_song = file_name + spotdl.args.output_ext
@@ -78,8 +81,8 @@ def test_metadata():
 def test_check_exists2():
     expect_check = True
     # prerequisites for determining filename
-    content = spotdl.go_pafy(raw_song)
-    songname = spotdl.generate_songname(raw_song)
+    meta_tags = spotdl.generate_metadata(raw_song)
+    songname = spotdl.generate_songname(meta_tags)
     file_name = spotdl.misc.sanitize_title(songname)
     input_song = file_name + spotdl.args.input_ext
     os.remove(os.path.join(spotdl.args.folder, input_song))

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -16,13 +16,13 @@ def test_spotify_title():
     assert title == expect_title
 
 
-def test_youtube_url():
+def youtube_url():
     expect_url = 'youtube.com/watch?v=rg1wfcty0BA'
     url = spotdl.generate_youtube_url(raw_song)
     assert url == expect_url
 
 
-def test_youtube_title():
+def youtube_title():
     expect_title = 'Intro - David André Østby'
     content = spotdl.go_pafy(raw_song)
     title = spotdl.get_youtube_title(content)


### PR DESCRIPTION
First, sorry for using old version :(

 - added .python-version
This file is used in pyenv to select good python version.

Changes in core/misc.py:
 - added function get_sec to convert HH:mm:ss to seconds

Changes in spotdl.py:
 - in function generate_songname
     change function to receive generate_metadata, this is optymalization, becouse in oldest version metadata from spotify api is downlaoded 2 times
 - in function generate_youtube_url
     song variable use changed function generate_songname
     function now looking for songs in while, and save data to dict. Dictionary is used in manual and auto mode. In dictionary keep is youtube link, title, videotime (in format HH:mm:ss) and videotime converted to seconds.
     For now in automatic downloading is selected video with least difference betwen youtube video time and time from spotify. This is important, becouse in youtube a lot of movies has scenes before/after without musics.