### PR TITLE
Expect Python to be already in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,11 @@ If it does not install correctly, you may have to build it from source. For more
 
 Assuming you have Python 3 already installed and in PATH.
 
-- Download and extract the [zip file](https://github.com/ritiek/spotify-downloader/archive/master.zip).
+- Download and extract the [zip file](https://github.com/ritiek/spotify-downloader/archive/master.zip) from master branch.
 
-- Download FFmpeg for Windows from [here](http://ffmpeg.zeranoe.com/builds/). Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH or just place it in the root directory extracted from the above step.
+- Download FFmpeg for Windows from [here](http://ffmpeg.zeranoe.com/builds/). Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH (usually C:\Windows\System32\) or just place it in the root directory extracted from the above step.
 
-- Open `cmd` to install dependencies:
-
- `pip.exe install -U -r requirements.txt`
+- Open `cmd` and type `pip install -U -r requirements.txt` to install dependencies.
 
 ## Instructions for Downloading Songs
 

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ If it does not install correctly, you may have to build it from source. For more
 
 ### Windows
 
-Assuming you have Python already installed..
+Assuming you have Python 3 already installed and in PATH.
 
-- Download FFmpeg for Windows from [here](http://ffmpeg.zeranoe.com/builds/). Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to `Scripts` folder (in your Python's installation directory: e.g. `C:\Python36\Scripts\ffmpeg.exe`)
+- Download and extract the [zip file](https://github.com/ritiek/spotify-downloader/archive/master.zip).
 
-- Download the [zip file](https://github.com/ritiek/spotify-downloader/archive/master.zip) of this repository and copy the folder contained in the archive into your Python's installation folder (e.g. `C:\Python36\spotify-downloader-master`).
+- Download FFmpeg for Windows from [here](http://ffmpeg.zeranoe.com/builds/). Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH or just place it in the root directory extracted from the above step.
 
-- Open the folder from last step. Shift+right-click on empty area, open `cmd`, navigate to your Python installation directory and type:
+- Open `cmd` to install dependencies:
 
-  `"Scripts/pip.exe" install -U -r requirements.txt`
-
-- If you do not want to naviagte to your Python folder from the command-line everytime you want to run the script, you can have your Python 'PATH' environment variables set and then you can run the script from any directory.
+ `pip.exe install -U -r requirements.txt`
 
 ## Instructions for Downloading Songs
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Assuming you have Python 3 already installed and in PATH.
 
 ## Instructions for Downloading Songs
 
-- For all available options, run `python spotdl.py --help` (or for Windows run `python.exe spotdl.py --help`).
+- For all available options, run `python spotdl.py --help`.
 
 ```
 usage: spotdl.py [-h] (-s SONG | -l LIST | -p PLAYLIST | -u USERNAME) [-m]

--- a/core/convert.py
+++ b/core/convert.py
@@ -2,6 +2,16 @@ import subprocess
 import os
 
 
+"""
+What are the differences and similarities between ffmpeg, libav, and avconv?
+https://stackoverflow.com/questions/9477115
+ffmeg encoders high to lower quality
+libopus > libvorbis >= libfdk_aac > aac > libmp3lame
+libfdk_aac due to copyrights needs to be compiled by end user
+on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
+https://trac.ffmpeg.org/wiki/Encode/AAC
+"""
+
 def song(input_song, output_song, folder, avconv=False, verbose=False):
     """Do the audio format conversion."""
     if not input_song == output_song:
@@ -17,17 +27,12 @@ def song(input_song, output_song, folder, avconv=False, verbose=False):
 
 def convert_with_avconv(input_song, output_song, folder, verbose):
     """Convert the audio file using avconv."""
-    if os.name == 'nt':
-        avconv_path = '..\\Scripts\\avconv.exe'
-    else:
-        avconv_path = 'avconv'
-
     if verbose:
         level = 'debug'
     else:
         level = '0'
 
-    command = [avconv_path,
+    command = ['avconv',
                '-loglevel', level,
                '-i',        os.path.join(folder, input_song),
                '-ab',       '192k',
@@ -37,27 +42,11 @@ def convert_with_avconv(input_song, output_song, folder, verbose):
 
 
 def convert_with_ffmpeg(input_song, output_song, folder, verbose):
-    """Convert the audio file using FFMpeg.
-
-    What are the differences and similarities between ffmpeg, libav, and avconv?
-    https://stackoverflow.com/questions/9477115
-    ffmeg encoders high to lower quality
-    libopus > libvorbis >= libfdk_aac > aac > libmp3lame
-    libfdk_aac due to copyrights needs to be compiled by end user
-    on MacOS brew install ffmpeg --with-fdk-aac will do just that. Other OS?
-    https://trac.ffmpeg.org/wiki/Encode/AAC
-    """
-
-    if os.name == "nt":
-        ffmpeg_pre = '..\\Scripts\\ffmpeg.exe '
-    else:
-        ffmpeg_pre = 'ffmpeg '
-
-    ffmpeg_pre += '-y '
+    """Convert the audio file using FFMpeg."""
+    ffmpeg_pre = 'ffmpeg -y '
     if not verbose:
         ffmpeg_pre += '-hide_banner -nostats -v panic '
 
-    ffmpeg_params = ''
     input_ext = input_song.split('.')[-1]
     output_ext = output_song.split('.')[-1]
 

--- a/core/convert.py
+++ b/core/convert.py
@@ -42,7 +42,7 @@ def convert_with_avconv(input_song, output_song, folder, verbose):
 
 
 def convert_with_ffmpeg(input_song, output_song, folder, verbose):
-    """Convert the audio file using FFMpeg."""
+    """Convert the audio file using FFmpeg."""
     ffmpeg_pre = 'ffmpeg -y '
     if not verbose:
         ffmpeg_pre += '-hide_banner -nostats -v panic '


### PR DESCRIPTION
Making these changes because Python 3 installers automatically add `python` and `pip` to PATH.