### PR TITLE
Reduce Travis CI build time by more than 90%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
   - chmod 777 $HOME/bin/ffmpeg
-  - ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,7 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev
-  - sudo apt-get -y install yasm nasm libmp3lame-dev
-  - mkdir ~/ffmpeg_sources
-  - cd ~/ffmpeg_sources
-  - wget http://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2
-  - tar jxf ffmpeg-snapshot.tar.bz2
-  - cd ffmpeg
-  - PATH="$HOME/bin:$PATH" PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --pkg-config-flags="--static" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --bindir="$HOME/bin" --enable-libmp3lame
-  - PATH="$HOME/bin:$PATH" make -s -j
-  - make install
-  - hash -r
-  - curl --upload-file $HOME/bin/ffmpeg https://transfer.sh/ffmpeg
+  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/
+  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - sudo apt-get -y install yasm nasm libmp3lame-dev
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
-  - chmod 755 $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
+  - wget https://transfer.sh/BlsO2/ffmpeg
+  - mv ffmpeg $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - PATH="$HOME/bin:$PATH" make -s -j
   - make install
   - hash -r
+  - curl --upload-file $HOME/bin/ffmpeg https://transfer.sh/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev
   - sudo apt-get -y install yasm nasm libmp3lame-dev
-  - sudo apt-get -y install ffmpeg
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
   - chmod 755 $HOME/bin/ffmpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install:
   - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev
   - sudo apt-get -y install yasm nasm libmp3lame-dev
   - sudo apt-get -y install ffmpeg
+  - mkdir $HOME/bin
+  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
   - chmod 777 $HOME/bin/ffmpeg
+  - ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - sudo apt-get -y install yasm nasm libmp3lame-dev
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
+  - chmod 755 $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - wget https://transfer.sh/BlsO2/ffmpeg
-  - mv ffmpeg $HOME/bin/
+  - mkdir $HOME/bin
+  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "3.5"
   - "3.6"
 before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev
+  - sudo apt-get -y install yasm nasm libmp3lame-dev
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
   - chmod 777 $HOME/bin/ffmpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 before_install:
   - wget https://transfer.sh/BlsO2/ffmpeg
-  - mv ffmpeg $HOME/bin/ffmpeg
+  - mv ffmpeg $HOME/bin/
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev
   - sudo apt-get -y install yasm nasm libmp3lame-dev
-  - mkdir $HOME/bin
-  - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
-  - chmod 777 $HOME/bin/ffmpeg
+  - sudo apt-get -y install ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get -y install ffmpeg
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
+  - chmod 755 $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 before_install:
   - mkdir $HOME/bin
   - wget https://transfer.sh/BlsO2/ffmpeg -O $HOME/bin/ffmpeg
+  - chmod 777 $HOME/bin/ffmpeg
 install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spotify-Downloader
 
+[![Build Status](https://travis-ci.org/ritiek/spotify-downloader.svg?branch=master)](https://travis-ci.org/ritiek/spotify-downloader)
+
 - Downloads songs from YouTube in an MP3 format by using Spotify's HTTP link.
 
 - Can also download a song by entering its artist and song name (in case if you don't have the Spotify's HTTP link for some song).


### PR DESCRIPTION
Travis CI now downloads a pre-compiled FFmpeg binary instead of building one on every run. Test duration dropped from 10 mins to about 50 secs.