### PR TITLE
Added handling for when there simply is no video

### DIFF
--- a/spotdl.py
+++ b/spotdl.py
@@ -81,6 +81,9 @@ def generate_youtube_url(raw_song):
             if meta_tags is None:
                 break
 
+    if not videos:
+        return None
+                
     if args.manual:
         print(song)
         print('')


### PR DESCRIPTION
Hey :)
I did not find any guidelines for contributing, so the layout is mine now. I am sorry.

**Problem:**
The script crashes when no youtube video is found for the search query.

**Error log:**
```
Traceback (most recent call last):
  File "spotdl.py", line 350, in <module>
    grab_single(raw_song=args.song)
  File "spotdl.py", line 301, in grab_single
    content = go_pafy(raw_song)
  File "spotdl.py", line 110, in go_pafy
    track_url = generate_youtube_url(raw_song)
  File "spotdl.py", line 102, in generate_youtube_url
    result = videos[0];
IndexError: list index out of range
```
**Song in question:**
https://open.spotify.com/track/4xaCDyW37pcgHxHr0nOLmh.

**Resulting youtube query:**
https://www.youtube.com/results?q=Martin%20Ermen%20-%20Father%20And%20Son&sp=CAMSAhABUBQ%253D


**Solution:**
Returning `None` if `videos` is empty makes it skip the song instead of spitting out errors.

**Additional notes:**
The edit was made in the browser, as it was quite small. I hope that did not mess up any formatting and I am sorry if it did. In such a case just close this PR and add the three lines (or a similar solution) yourself.

***Have a nice day!***