### PR TITLE
Improves accuracy of selected youtube video

### DIFF
--- a/core/misc.py
+++ b/core/misc.py
@@ -103,9 +103,10 @@ def generate_search_url(song, viewsort=False):
     # urllib.request.quote() encodes URL with special characters
     song = quote(song)
     if viewsort:
-        url = u"https://www.youtube.com/results?q={0}&sp=CAMSAhABUBQ%253D".format(song)
+        url = u"https://www.youtube.com/results?q={0}".format(song)
     else:
         url = u"https://www.youtube.com/results?sp=EgIQAQ%253D%253D&q={0}".format(song)
+
     return url
 
 


### PR DESCRIPTION
Finds a balance between viewcount (Youtube's relevancy) and proper song
duration based on Spotify duration. Thus, a Youtube video that is 30
seconds longer than the Spotify track will not be considered

Takes the first result from Youtube (using Youtube's original ordering
based on relevance) that has a similar duration to the Spotify song

Fixes a bug where if there were no suitable videos for a song, the
program would infinitely loop. The program will now retry to find a song
up to 5 times before moving on (this is necessary because occasionally the
song isn't properly fetched or parsed from Youtube)

Fixes bug where songs that are retried were appended to the playlist
file without being separated by a newline