### PR TITLE
Add an option to grab an album

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ optional arguments:
   -p PLAYLIST, --playlist PLAYLIST
                         load songs from playlist URL into <playlist_name>.txt
                         (default: None)
+  -b ALBUM, --album ALBUM
+                        load songs from album URL into <album_name>.txt
+                        (default: None)
   -u USERNAME, --username USERNAME
                         load songs from user's playlist into
                         <playlist_name>.txt (default: None)
@@ -164,6 +167,18 @@ For example
 - The script will load all the tracks from the playlist into `<playlist_name>.txt`
 
 - Then you can simply run `python3 spotdl.py --list=<playlist_name>.txt` to download all the tracks.
+
+#### Download albums
+
+- You can copy the Spotify URL of the album and pass it in `--album` option.
+
+For example
+
+- `python3 spotdl.py --album https://open.spotify.com/album/7CjakTZxwIF8oixONe6Bpb`
+
+- The script will load all the tracks from the album into `<album_name>.txt`
+
+- Then you can simply run `python3 spotdl.py --list=<album_name>.txt` to download all the tracks.
 
 #### Download playlists by username
 

--- a/core/misc.py
+++ b/core/misc.py
@@ -42,6 +42,8 @@ def get_arguments():
     group.add_argument(
         '-p', '--playlist', help='load songs from playlist URL into <playlist_name>.txt')
     group.add_argument(
+        '-b', '--album', help='load songs from album URL into <album_name>.txt')
+    group.add_argument(
         '-u', '--username',
         help="load songs from user's playlist into <playlist_name>.txt")
     parser.add_argument(


### PR DESCRIPTION
This adds a `-b, --album` option taking an album URL (e.g.: https://open.spotify.com/album/7CjakTZxwIF8oixONe6Bpb) to download all the tracks of the album.

I moved the part of `write_tracks` that's specific to playlists into a `write_playlist` that calls the now more generic `write_tracks` function, in order for `write_tracks` to be reused by the new `write_album` function.