### PR TITLE
Add docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6-alpine
+
+RUN apk add --no-cache \
+    ffmpeg
+
+ADD requirements.txt /app/
+RUN cd /app && pip install -U -r requirements.txt
+
+ADD spotdl.py /app/
+ADD core/ /app/core
+
+WORKDIR /app
+
+ENTRYPOINT ["python3", "spotdl.py", "-f", "."]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Assuming you have Python 3 ([preferably v3.6 or above to stay away from Unicode 
 
 - Open `cmd` and type `pip install -U -r requirements.txt` to install dependencies. The same note about `pip` as for Debian, Ubuntu, Linux & Mac applies.
 
+## Docker
+
+Create the docker image and use the `-s` `-p` `-l` to download single song, prepare playlist and download list file.
+
+```
+docker build -t ritiek/spotdl .
+docker run --rm -v $(pwd):/app ritiek/spotdl -s https://open.spotify.com/track/4eSv18SwAXoQJF6tPqFIyw
+docker run --rm -v $(pwd):/app ritiek/spotdl -p https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX2iUghHXGIjj
+docker run --rm -v $(pwd):/app ritiek/spotdl -l acoustic-blues.txt
+```
+
 ## Instructions for Downloading Songs
 
 


### PR DESCRIPTION
I am not used to have a python environment. So I create a docker image to simplify the installation process. 

The PR contains a Dockerfile that could be used for automated builds and a script that could be left out to avoid opinionated paths/workflow.

For sure my handle should go away from the code if there's interest in merging this.