### PR TITLE
Add --overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ and it will start downloading songs mentioned in `list.txt`.
 resume from the song where you stopped it the next time you want to download
 the songs present in `list.txt`.
 
-- Songs that are already downloaded will be skipped and not be downloaded again.
+- Songs that are already downloaded will prompt you to overwrite or skip. This behavior can be changed by
+passing `--overwrite {prompt,skip,force}`.
 
 #### Download by Playlist Link
 

--- a/core/internals.py
+++ b/core/internals.py
@@ -63,6 +63,10 @@ def get_arguments():
         '-f', '--folder', default=(os.path.join(sys.path[0], 'Music')),
         help='path to folder where files will be stored in')
     parser.add_argument(
+        '--overwrite', default='prompt',
+        help='change the overwrite policy',
+        choices={'prompt', 'force', 'skip'})
+    parser.add_argument(
         '-i', '--input-ext', default='.m4a',
         help='prefered input format .m4a or .webm (Opus)')
     parser.add_argument(

--- a/spotdl.py
+++ b/spotdl.py
@@ -405,11 +405,6 @@ def grab_album(album):
 
 def grab_single(raw_song, number=None):
     """ Logic behind downloading a song. """
-    if number:
-        islist = True
-    else:
-        islist = False
-
     if internals.is_youtube(raw_song):
         log.debug('Input song is a YouTube URL')
         content = go_pafy(raw_song, meta_tags=None)

--- a/spotdl.py
+++ b/spotdl.py
@@ -280,7 +280,7 @@ def download_song(file_name, content):
         return True
 
 
-def check_exists(music_file, raw_song, meta_tags, islist=True):
+def check_exists(music_file, raw_song, meta_tags):
     """ Check if the input song already exists in the given folder. """
     log.debug('Cleaning any temp files and checking '
               'if "{}" already exists'.format(music_file))
@@ -304,11 +304,8 @@ def check_exists(music_file, raw_song, meta_tags, islist=True):
                     os.remove(os.path.join(args.folder, song))
                     return False
 
-            # if downloading only single song, prompt to re-download
-            if islist:
-                log.warning('"{}" already exists'.format(song))
-                return True
-            else:
+            log.warning('"{}" already exists'.format(song))
+            if args.overwrite == 'prompt':
                 log.info('"{}" has already been downloaded. '
                          'Re-download? (y/N): '.format(song))
                 prompt = input('> ')
@@ -317,6 +314,13 @@ def check_exists(music_file, raw_song, meta_tags, islist=True):
                     return False
                 else:
                     return True
+            elif args.overwrite == 'force':
+                os.remove(os.path.join(args.folder, song))
+                log.info('Overwriting "{}"'.format(song))
+                return False
+            elif args.overwrite == 'skip':
+                log.info('Skipping "{}"'.format(song))
+                return True
     return False
 
 
@@ -433,7 +437,7 @@ def grab_single(raw_song, number=None):
 
     file_name = internals.sanitize_title(songname)
 
-    if not check_exists(file_name, raw_song, meta_tags, islist=islist):
+    if not check_exists(file_name, raw_song, meta_tags):
         if download_song(file_name, content):
             input_song = file_name + args.input_ext
             output_song = file_name + args.output_ext

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -13,7 +13,7 @@ class TestArgs:
     output_ext = '.mp3'
     folder = 'test'
     log_level = logger.logging.DEBUG
-    overwrite = 'prompt'
+    overwrite = 'skip'
 
 test_args = TestArgs()
 setattr(spotdl, "args", test_args)

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -13,6 +13,7 @@ class TestArgs:
     output_ext = '.mp3'
     folder = 'test'
     log_level = logger.logging.DEBUG
+    overwrite = 'prompt'
 
 test_args = TestArgs()
 setattr(spotdl, "args", test_args)
@@ -39,7 +40,7 @@ def test_check_exists():
     expect_check = False
     # prerequisites for determining filename
     file_name = spotdl.internals.sanitize_title(title)
-    check = spotdl.check_exists(file_name, raw_song, meta_tags=None, islist=True)
+    check = spotdl.check_exists(file_name, raw_song, meta_tags=None)
     assert check == expect_check
 
 
@@ -79,6 +80,6 @@ def test_check_exists2():
     # prerequisites for determining filename
     file_name = spotdl.internals.sanitize_title(title)
     os.remove(os.path.join(spotdl.args.folder, input_song))
-    check = spotdl.check_exists(file_name, raw_song, meta_tags=None, islist=True)
+    check = spotdl.check_exists(file_name, raw_song, meta_tags=None)
     os.remove(os.path.join(spotdl.args.folder, output_song))
     assert check == expect_check

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -13,7 +13,7 @@ class TestArgs:
     output_ext = '.mp3'
     folder = 'test'
     log_level = 'DEBUG'
-    overwrite = 'prompt'
+    overwrite = 'skip'
 
 test_args = TestArgs()
 setattr(spotdl, "args", test_args)

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -13,6 +13,7 @@ class TestArgs:
     output_ext = '.mp3'
     folder = 'test'
     log_level = 'DEBUG'
+    overwrite = 'prompt'
 
 test_args = TestArgs()
 setattr(spotdl, "args", test_args)
@@ -49,7 +50,7 @@ def test_check_exists():
     songname = spotdl.generate_songname(meta_tags)
     global file_name
     file_name = spotdl.internals.sanitize_title(songname)
-    check = spotdl.check_exists(file_name, raw_song, meta_tags, islist=True)
+    check = spotdl.check_exists(file_name, raw_song, meta_tags)
     assert check == expect_check
 
 
@@ -85,6 +86,6 @@ def test_check_exists2():
     expect_check = True
     # prerequisites for determining filename
     os.remove(os.path.join(spotdl.args.folder, input_song))
-    check = spotdl.check_exists(file_name, raw_song, meta_tags, islist=True)
+    check = spotdl.check_exists(file_name, raw_song, meta_tags)
     os.remove(os.path.join(spotdl.args.folder, output_song))
     assert check == expect_check


### PR DESCRIPTION
This PR adds an `--overwrite` flag option.

Previously, if a single song was already downloaded, the user would be prompted whether to overwrite. Now the user can use `--overwrite force` or `--overwrite skip` to say yes or no respectively.

This also gets rid of the default skip behavior for lists. I don't know if that will end up breaking anyone's usages.

Fixes: #181 