### PR TITLE
Homebrew install method for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Installing with Homebrew automatically completes the next step.
 
 **Important:** if you have installed both Python 2 and 3, the `pip` command
 could invoke an installation for Python 2. To see which Python version `pip`
-refers to, try `pip -V`. If it turns out `python` is your Python 2 pip, try
-`pip3 setup.py install` instead.
+refers to, try `pip -V`. If it turns out `pip` is your Python 2 pip, try
+`pip3 install -U -r requirements.txt` instead.
 
 You'll also need to install FFmpeg for conversion
 (use `--avconv` if you'd like to use that instead):
@@ -94,12 +94,12 @@ Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH
 (usually C:\Windows\System32\) or just place it in the root directory extracted
 from the above step.
 
-- Open `cmd` and type `pip install -U -r requirements.txt` to install.
+- Open `cmd` and type `pip install -U -r requirements.txt` to install dependencies.
 The same note about `pip` as for Debian, Ubuntu, Linux & Mac applies.
 
 ## Instructions for Downloading Songs
 
-**Important:** There might be no `python3` command.
+**Important:** as like with `pip`, there `python3` command.
 This is most likely the case when you have only Python 3 but not 2 installed.
 In this case try the `python` command instead of `python3`,
 but make sure `python -V` gives you a `Python 3.x.x`! If you installed with Homebrew on Mac, run all the commands without `python3` prepended.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The same note about `pip` as for Debian, Ubuntu, Linux & Mac applies.
 
 ## Instructions for Downloading Songs
 
-**Important:** as like with `pip`, there `python3` command.
+**Important:** as like with `pip`, there might be no `python3` command.
 This is most likely the case when you have only Python 3 but not 2 installed.
 In this case try the `python` command instead of `python3`,
 but make sure `python -V` gives you a `Python 3.x.x`! If you installed with Homebrew on Mac, run all the commands without `python3` prepended.

--- a/README.md
+++ b/README.md
@@ -59,10 +59,17 @@ cd spotify-downloader
 pip install -U -r requirements.txt
 ```
 
+If you have Homebrew on Mac you can install instead with:
+```
+brew tap austharlow/homebrew-austharlow
+brew install spotify-downloader
+```
+Installing with Homebrew automatically completes the next step.
+
 **Important:** if you have installed both Python 2 and 3, the `pip` command
 could invoke an installation for Python 2. To see which Python version `pip`
-refers to, try `pip -V`. If it turns out `pip` is your Python 2 pip, try
-`pip3 install -U -r requirements.txt` instead.
+refers to, try `pip -V`. If it turns out `python` is your Python 2 pip, try
+`pip3 setup.py install` instead.
 
 You'll also need to install FFmpeg for conversion
 (use `--avconv` if you'd like to use that instead):
@@ -87,15 +94,15 @@ Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH
 (usually C:\Windows\System32\) or just place it in the root directory extracted
 from the above step.
 
-- Open `cmd` and type `pip install -U -r requirements.txt` to install dependencies.
+- Open `cmd` and type `pip install -U -r requirements.txt` to install.
 The same note about `pip` as for Debian, Ubuntu, Linux & Mac applies.
 
 ## Instructions for Downloading Songs
 
-**Important:** as like with `pip`, there might be no `python3` command.
+**Important:** There might be no `python3` command.
 This is most likely the case when you have only Python 3 but not 2 installed.
 In this case try the `python` command instead of `python3`,
-but make sure `python -V` gives you a `Python 3.x.x`!
+but make sure `python -V` gives you a `Python 3.x.x`! If you installed with Homebrew on Mac, run all the commands without `python3` prepended.
 
 - For all available options, run `python3 spotdl.py --help`.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you need to use Python 2 though, check out the (old) `python2` branch.
 since they were not of much use and created unnecessary clutter.
 You can still get them back by using `old` branch though.
 
-### Debian, Ubuntu, Linux & Mac
+### Debian, Ubuntu, Linux & macOS
 
 ```
 cd
@@ -59,12 +59,12 @@ cd spotify-downloader
 pip install -U -r requirements.txt
 ```
 
-If you have Homebrew on Mac you can install instead with:
+If you have Homebrew on macOS you can instead install with:
 ```
 brew tap austharlow/homebrew-austharlow
 brew install spotify-downloader
 ```
-Installing with Homebrew automatically completes the next step.
+Installing with Homebrew automatically installs FFmpeg.
 
 **Important:** if you have installed both Python 2 and 3, the `pip` command
 could invoke an installation for Python 2. To see which Python version `pip`
@@ -76,7 +76,7 @@ You'll also need to install FFmpeg for conversion
 
 Linux: `sudo apt-get install ffmpeg`
 
-Mac: `brew install ffmpeg --with-libmp3lame --with-libass --with-opus --with-fdk-aac`
+macOS: `brew install ffmpeg --with-libmp3lame --with-libass --with-opus --with-fdk-aac`
 
 If it does not install correctly, you may have to build it from source.
 For more info see https://trac.ffmpeg.org/wiki/CompilationGuide.
@@ -95,14 +95,14 @@ Copy `ffmpeg.exe` from `ffmpeg-xxx-winxx-static\bin\ffmpeg.exe` to PATH
 from the above step.
 
 - Open `cmd` and type `pip install -U -r requirements.txt` to install dependencies.
-The same note about `pip` as for Debian, Ubuntu, Linux & Mac applies.
+The same note about `pip` as for Debian, Ubuntu, Linux & macOS applies.
 
 ## Instructions for Downloading Songs
 
 **Important:** as like with `pip`, there might be no `python3` command.
 This is most likely the case when you have only Python 3 but not 2 installed.
 In this case try the `python` command instead of `python3`,
-but make sure `python -V` gives you a `Python 3.x.x`! If you installed with Homebrew on Mac, run all the commands without `python3` prepended.
+but make sure `python -V` gives you a `Python 3.x.x`! If you installed with Homebrew on macOS, run all the commands without `python3` prepended.
 
 - For all available options, run `python3 spotdl.py --help`.
 

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,4 @@ setup(name='Spotify Downloader',
         'titlecase',
         'logzero',
       ]
-      )
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from disutils.core import setup
+from distutils.core import setup
 
 setup(name='Spotify Downloader',
       description='Download Spotify playlists with albumart and meta-tags',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+from disutils.core import setup
+
+setup(name='Spotify Downloader',
+      description='Download Spotify playlists with albumart and meta-tags',
+      author='Ritiek Malhotra',
+      author_email='ritiekmalhotra123@gmail.com',
+      url='https://github.com/ritiek/spotify-downloader',
+      license='MIT',
+      packages=['core'],
+      scripts=['spotdl.py'],
+      install_requires=[
+        'pathlib',
+        'BeautilfulSoup4',
+        'youtube_dl',
+        'pafy',
+        'spotipy',
+        'mutagen',
+        'unicode-slugify',
+        'titlecase',
+        'logzero',
+      ]
+      )

--- a/spotdl.py
+++ b/spotdl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 from core import logger


### PR DESCRIPTION
Added instructions on how to install with Hombrew on macOS (hosted in my tap), along with a setup.py file which is required for installing this way.