### PR TITLE
Read configuration from config.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+config.yml
+Music/
+*.txt
+
 *.pyc
 __pycache__/
 .cache/
-Music/
-*.txt
 .python-version

--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ command after downloading is done:
 
 Just make sure your working directory is the one you have the music files in.
 
+## Config File
+
+At first run, this tool will generate a `config.yml` in root directory
+of the code base with default options. You can then modify `config.yml`
+to override any default options.
+
+Also note that config options are overridden by command-line arguments.
+
 ## [Docker Image](https://hub.docker.com/r/ritiek/spotify-downloader/)
 [![Docker automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/ritiek/spotify-downloader)
 

--- a/core/handle.py
+++ b/core/handle.py
@@ -1,10 +1,27 @@
 import logging
+import yaml
 import argparse
+
 import os
 import sys
 
 
 _LOG_LEVELS_STR = ['INFO', 'WARNING', 'ERROR', 'DEBUG']
+
+default_conf = { 'spotify-downloader':
+                 { 'manual'                 : False,
+                   'no-metadata'            : False,
+                   'avconv'                 : False,
+                   'folder'                 : os.path.join(sys.path[0], 'Music'),
+                   'overwrite'              : 'prompt',
+                   'input-ext'              : '.m4a',
+                   'output-ext'             : '.mp3',
+                   'download-only-metadata' : False,
+                   'dry-run'                : False,
+                   'music-videos-only'      : False,
+                   'log-level'              : 'INFO' }
+               }
+
 
 def log_leveller(log_level_str):
     loggin_levels = [logging.INFO, logging.WARNING, logging.ERROR, logging.DEBUG]
@@ -13,10 +30,32 @@ def log_leveller(log_level_str):
     return loggin_level
 
 
+def merge(default, config):
+    """ Override default dict with config dict. """
+    merged = default.copy()
+    merged.update(config)
+    return merged
+
+
+def get_config(config_file):
+    try:
+        with open(config_file, 'r') as ymlfile:
+            cfg = yaml.load(ymlfile)
+    except FileNotFoundError:
+        with open(config_file, 'w') as ymlfile:
+            yaml.dump(default_conf, ymlfile, default_flow_style=False)
+            cfg = default_conf
+
+    return cfg['spotify-downloader']
+
+
 def get_arguments(to_group=True, raw_args=None):
     parser = argparse.ArgumentParser(
         description='Download and convert songs from Spotify, Youtube etc.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    config_file = os.path.join(sys.path[0], 'config.yml')
+    config = merge(default_conf, get_config(config_file))
 
     if to_group:
         group = parser.add_mutually_exclusive_group(required=True)
@@ -34,42 +73,42 @@ def get_arguments(to_group=True, raw_args=None):
             help="load songs from user's playlist into <playlist_name>.txt")
 
     parser.add_argument(
-        '-m', '--manual', default=False,
+        '-m', '--manual', default=config['manual'],
         help='choose the song to download manually', action='store_true')
     parser.add_argument(
-        '-nm', '--no-metadata', default=False,
+        '-nm', '--no-metadata', default=config['no-metadata'],
         help='do not embed metadata in songs', action='store_true')
     parser.add_argument(
-        '-a', '--avconv', default=False,
+        '-a', '--avconv', default=config['avconv'],
         help='Use avconv for conversion otherwise set defaults to ffmpeg',
         action='store_true')
     parser.add_argument(
-        '-f', '--folder', default=(os.path.join(sys.path[0], 'Music')),
+        '-f', '--folder', default=config['folder'],
         help='path to folder where files will be stored in')
     parser.add_argument(
-        '--overwrite', default='prompt',
+        '--overwrite', default=config['overwrite'],
         help='change the overwrite policy',
         choices={'prompt', 'force', 'skip'})
     parser.add_argument(
-        '-i', '--input-ext', default='.m4a',
+        '-i', '--input-ext', default=config['input-ext'],
         help='prefered input format .m4a or .webm (Opus)')
     parser.add_argument(
-        '-o', '--output-ext', default='.mp3',
+        '-o', '--output-ext', default=config['output-ext'],
         help='prefered output extension .mp3 or .m4a (AAC)')
     parser.add_argument(
-        '-dm', '--download-only-metadata', default=False,
+        '-dm', '--download-only-metadata', default=config['download-only-metadata'],
         help='download songs for which metadata is found',
         action='store_true')
     parser.add_argument(
-        '-d', '--dry-run', default=False,
+        '-d', '--dry-run', default=config['dry-run'],
         help='Show only track title and YouTube URL',
         action='store_true')
     parser.add_argument(
-        '-mo', '--music-videos-only', default=False,
+        '-mo', '--music-videos-only', default=config['music-videos-only'],
         help='Search only for music on Youtube',
         action='store_true')
     parser.add_argument(
-        '-ll', '--log-level', default='INFO',
+        '-ll', '--log-level', default=config['log-level'],
         choices=_LOG_LEVELS_STR,
         type=str.upper,
         help='set log verbosity')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ unicode-slugify >= 0.1.3
 titlecase >= 0.10.0
 logzero >= 1.3.1
 lyricwikia >= 0.1.8
+PyYAML >= 3.12


### PR DESCRIPTION
This PR adds the ability to read configuration from `config.yml`, convenient for users who don't like to stick with defaults and have to pass long arguments each time they invoke the script.