### PR TITLE
Use enumerate, remove random usages of exit codes

### DIFF
--- a/spotdl.py
+++ b/spotdl.py
@@ -114,14 +114,14 @@ def grab_playlist(playlist):
     except IndexError:
         # Wrong format, in either case
         log.error('The provided playlist URL is not in a recognized format!')
-        sys.exit(1)
+        sys.exit(10)
     playlist_id = splits[-1]
     try:
         spotify_tools.write_playlist(username, playlist_id)
     except spotipy.client.SpotifyException:
         log.error('Unable to find playlist')
         log.info('Make sure the playlist is set to publicly visible and then try again')
-        sys.exit(1)
+        sys.exit(11)
 
 
 def grab_single(raw_song, number=None):
@@ -219,4 +219,4 @@ if __name__ == '__main__':
 
     except KeyboardInterrupt as e:
         log.exception(e)
-        sys.exit(1)
+        sys.exit(3)

--- a/spotdl.py
+++ b/spotdl.py
@@ -72,12 +72,11 @@ def grab_list(text_file):
     except ValueError:
         pass
     log.info(u'Preparing to download {} songs'.format(len(lines)))
-    number = 1
 
-    for raw_song in lines:
+    for number, raw_song in enumerate(lines):
         print('')
         try:
-            grab_single(raw_song, number=number)
+            grab_single(raw_song, number=number+1)
         # token expires after 1 hour
         except spotipy.client.SpotifyException:
             # refresh token when it expires
@@ -100,7 +99,6 @@ def grab_list(text_file):
 
         log.debug('Removing downloaded song from text file')
         internals.trim_song(text_file)
-        number += 1
 
 
 def grab_playlist(playlist):
@@ -116,14 +114,14 @@ def grab_playlist(playlist):
     except IndexError:
         # Wrong format, in either case
         log.error('The provided playlist URL is not in a recognized format!')
-        sys.exit(10)
+        sys.exit(1)
     playlist_id = splits[-1]
     try:
         spotify_tools.write_playlist(username, playlist_id)
     except spotipy.client.SpotifyException:
         log.error('Unable to find playlist')
         log.info('Make sure the playlist is set to publicly visible and then try again')
-        sys.exit(11)
+        sys.exit(1)
 
 
 def grab_single(raw_song, number=None):
@@ -221,4 +219,4 @@ if __name__ == '__main__':
 
     except KeyboardInterrupt as e:
         log.exception(e)
-        sys.exit(3)
+        sys.exit(1)


### PR DESCRIPTION
As per the documentation for `sys.exit` most codes besides 0 and 1 are underdeveloped and produce mostly undefined results. Nothing wrong with sticking to the safe route.