### PR TITLE
Fix already_tagged check for mp4 in metadata.py>compare

### DIFF
--- a/core/metadata.py
+++ b/core/metadata.py
@@ -14,7 +14,7 @@ def compare(music_file, metadata):
             already_tagged = audiofile['title'][0] == metadata['name']
         elif music_file.endswith('.m4a'):
             audiofile = MP4(music_file)
-            already_tagged = audiofile[tags['title']] == metadata['name']
+            already_tagged = audiofile['\xa9nam'][0] == metadata['name']
     except (KeyError, TypeError):
         already_tagged = False
 


### PR DESCRIPTION
This fixes an error I faced when I tried to download songs from a spotify playlist:

**Playlist:**  https://open.spotify.com/user/rorosaurus/playlist/7JUeuEHTuZ9bNHSi8MjvpC

**Stack trace:**
```
INFO: 1. Green Fields - Brothers Four (CD Quality) (http://www.youtube.com/watch?v=46o1joHp7t0)
Traceback (most recent call last):
  File "spotdl.py", line 208, in <module>
    grab_list(text_file=const.args.list)
  File "spotdl.py", line 78, in grab_list
    grab_single(raw_song, number=number+1)
  File "spotdl.py", line 165, in grab_single
    if not check_exists(songname, raw_song, meta_tags):
  File "spotdl.py", line 37, in check_exists
    meta_tags)
  File "D:\repos\spotify-downloader\core\metadata.py", line 17, in compare
    already_tagged = audiofile[tags['title']] == metadata['name']
NameError: name 'tags' is not defined
```

Not 100% sure about the fix though. Please check.