### PR TITLE
Slugify filenames when metadata found on Spotify too

### DIFF
--- a/core/internals.py
+++ b/core/internals.py
@@ -66,7 +66,7 @@ def is_youtube(raw_song):
     return status
 
 
-def format_string(string_format, tags):
+def format_string(string_format, tags, slugification=False):
     """ Generate a string of the format '[artist] - [song]' for the given spotify song. """
     format_tags = dict(formats)
     format_tags[0]  = tags['name']
@@ -82,9 +82,17 @@ def format_string(string_format, tags):
     format_tags[10] = tags['total_tracks']
     format_tags[11] = tags['external_ids']['isrc']
 
+    for tag in format_tags:
+        if slugification:
+            format_tags[tag] = sanitize_title(format_tags[tag],
+                                              ok='-_()[]{}')
+        else:
+            format_tags[tag] = str(format_tags[tag])
+
     for x in formats:
-        string_format = string_format.replace('{' + formats[x] + '}',
-                                          str(format_tags[x]))
+        format_tag = '{' + formats[x] + '}'
+        string_format = string_format.replace(format_tag,
+                                              format_tags[x])
 
     if const.args.no_spaces:
         string_format = string_format.replace(' ', '_')
@@ -92,14 +100,14 @@ def format_string(string_format, tags):
     return string_format
 
 
-def sanitize_title(title):
+def sanitize_title(title, ok='-_()[]{}\/'):
     """ Generate filename of the song to be downloaded. """
 
     if const.args.no_spaces:
         title = title.replace(' ', '_')
 
     # slugify removes any special characters
-    title = slugify(title, ok='-_()[]{}\/', lower=False, spaces=True)
+    title = slugify(title, ok=ok, lower=False, spaces=True)
     return title
 
 

--- a/core/spotify_tools.py
+++ b/core/spotify_tools.py
@@ -67,9 +67,10 @@ def generate_metadata(raw_song):
     except lyricwikia.LyricsNotFound:
         meta_tags['lyrics'] = None
 
-    # fix clutter
+    # Some sugar
     meta_tags['year'], *_ = meta_tags['release_date'].split('-')
     meta_tags['duration'] = meta_tags['duration_ms'] / 1000.0
+    # Remove unwanted parameters
     del meta_tags['duration_ms']
     del meta_tags['available_markets']
     del meta_tags['album']['available_markets']

--- a/spotdl.py
+++ b/spotdl.py
@@ -132,7 +132,9 @@ def download_single(raw_song, number=None):
     songname = content.title
 
     if meta_tags is not None:
-        refined_songname = internals.format_string(const.args.file_format, meta_tags)
+        refined_songname = internals.format_string(const.args.file_format,
+                                                   meta_tags,
+                                                   slugification=True)
         log.debug('Refining songname from "{0}" to "{1}"'.format(songname, refined_songname))
         if not refined_songname == ' - ':
             songname = refined_songname


### PR DESCRIPTION
Fixes #239.

We already run slugify on tracks when metadata is not found on Spotify (possible when not using Spotify track URI to download some song). I did not realize that is possible for tracks on Spotify to have special characters as well.

This PR fixes this issue.

**P.S.** Since, I am not close to a Windows for a few upcoming days. I'd be happy if someone can test these changes on a Windows machine to speed up things a bit.
Try downloading this track with debug mode enabled:
https://open.spotify.com/track/0MsrWnxQZxPAcov7c74sSo
and let me have the output. :smile: