### PR TITLE
Add support for Ogg (Opus and Vorbis)

### DIFF
--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -111,12 +111,16 @@ class Converter:
                 ffmpeg_params = "-codec:a libopus -vbr on "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
+            elif self.output_ext == ".ogg":
+            	ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on " # Opus doesn't support 44.1k
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:a libmp3lame -ar 44100 "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
+            elif self.output_ext == ".ogg":
+            	ffmpeg_params = "-vn -codec:a copy "
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -111,8 +111,7 @@ class Converter:
                 ffmpeg_params = "-codec:a libopus -vbr on "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
-            # Most Android versions need .ogg for both Opus and Vorbis, so allow .[codec].ogg
-            elif self.output_ext in (".opus", ".opus.ogg"):
+            elif self.output_ext == ".opus":
                 # Opus doesn't support 44.1k
                 ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
 
@@ -122,14 +121,15 @@ class Converter:
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
             # Audio in YouTube WebM files is Opus
-            elif self.output_ext in (".opus", ".opus.ogg"):
+            elif self.output_ext == ".opus":
                 ffmpeg_params = "-codec:a copy "
 
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
-        elif self.output_ext in (".ogg", ".vorbis.ogg"):
+        elif self.output_ext == ".ogg":
             ffmpeg_params = "-codec:a libvorbis -ar 44100 "
+            log.info("Vorbis")
 
         # add common params for any of the above combination
         ffmpeg_params += "-b:a 192k -vn "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -111,15 +111,25 @@ class Converter:
                 ffmpeg_params = "-codec:a libopus -vbr on "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
+            # Most Android versions need .ogg for both Opus and Vorbis, so allow .[codec].ogg
+            elif self.output_ext in (".opus", ".opus.ogg"):
+                # Opus doesn't support 44.1k
+                ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:a libmp3lame -ar 44100 "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
+            # Audio in YouTube WebM files is Opus
+            elif self.output_ext in (".opus", ".opus.ogg"):
+                ffmpeg_params = "-codec:a copy "
+
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
+        elif self.output_ext in (".ogg", ".vorbis.ogg"):
+            ffmpeg_params = "-codec:a libvorbis -ar 44100 "
 
         # add common params for any of the above combination
         ffmpeg_params += "-b:a 192k -vn "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -125,7 +125,7 @@ class Converter:
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
         elif output_ext == ".oga":
-            	ffmpeg_params = "-codec:a libvorbis -ar 44100 "
+            ffmpeg_params = "-codec:a libvorbis -ar 44100 "
 
         # add common params for any of the above combination
         ffmpeg_params += "-b:a 192k -vn "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -111,22 +111,18 @@ class Converter:
                 ffmpeg_params = "-codec:a libopus -vbr on "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
-            elif self.output_ext == ".opus":
-                # Opus doesn't support 44.1k
-                ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:a libmp3lame -ar 44100 "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
-            # Audio in YouTube WebM files is Opus
-            elif self.output_ext == ".opus":
-                ffmpeg_params = "-codec:a copy "
-
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
+        elif self.output_ext == ".opus":
+            # Opus doesn't support 44.1k
+            ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
         elif self.output_ext == ".ogg":
             ffmpeg_params = "-codec:a libvorbis -ar 44100 "
             log.info("Vorbis")

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -125,7 +125,7 @@ class Converter:
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
-        elif output_ext == ".oga":
+        elif self.output_ext == ".oga":
             ffmpeg_params = "-codec:a libvorbis -ar 44100 "
 
         # add common params for any of the above combination

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -120,10 +120,12 @@ class Converter:
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
             elif self.output_ext == ".ogg":
-            	ffmpeg_params = "-vn -codec:a copy "
+            	ffmpeg_params = "-codec:a copy "
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
+        elif output_ext == ".oga":
+            	ffmpeg_params = "-codec:a libvorbis -ar 44100 "
 
         # add common params for any of the above combination
         ffmpeg_params += "-b:a 192k -vn "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -111,22 +111,15 @@ class Converter:
                 ffmpeg_params = "-codec:a libopus -vbr on "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
-            elif self.output_ext == ".ogg":
-                # Opus doesn't support 44.1k
-            	ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:a libmp3lame -ar 44100 "
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
-            elif self.output_ext == ".ogg":
-            	ffmpeg_params = "-codec:a copy "
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
-        elif self.output_ext == ".oga":
-            ffmpeg_params = "-codec:a libvorbis -ar 44100 "
 
         # add common params for any of the above combination
         ffmpeg_params += "-b:a 192k -vn "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -112,7 +112,8 @@ class Converter:
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
             elif self.output_ext == ".ogg":
-            	ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on " # Opus doesn't support 44.1k
+                # Opus doesn't support 44.1k
+            	ffmpeg_params = "-codec:a libopus -ar 48000 -vbr on "
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -183,7 +183,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "-o",
         "--output-ext",
         default=config["output-ext"],
-        help="preferred output format .mp3, .m4a (AAC), .flac, .ogg (Opus), .oga (Vorbis), etc.",
+        help="preferred output format .mp3, .m4a (AAC), .flac, etc.",
     )
     parser.add_argument(
         "--write-to",

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -183,7 +183,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "-o",
         "--output-ext",
         default=config["output-ext"],
-        help="preferred output format .mp3, .m4a (AAC), .flac, etc.",
+        help="preferred output format .mp3, .m4a (AAC), .flac, .opus[.ogg], [.vorbis].ogg etc.",
     )
     parser.add_argument(
         "--write-to",

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -183,7 +183,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "-o",
         "--output-ext",
         default=config["output-ext"],
-        help="preferred output format .mp3, .m4a (AAC), .flac, etc.",
+        help="preferred output format .mp3, .m4a (AAC), .flac, .ogg (Opus), .oga (Vorbis), etc.",
     )
     parser.add_argument(
         "--write-to",

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -183,7 +183,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "-o",
         "--output-ext",
         default=config["output-ext"],
-        help="preferred output format .mp3, .m4a (AAC), .flac, .opus[.ogg], [.vorbis].ogg etc.",
+        help="preferred output format .mp3, .m4a (AAC), .flac, .opus, .ogg (Vorbis), etc.",
     )
     parser.add_argument(
         "--write-to",

--- a/spotdl/metadata.py
+++ b/spotdl/metadata.py
@@ -5,7 +5,6 @@ from mutagen.mp4 import MP4, MP4Cover
 from mutagen.flac import Picture, FLAC
 from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
-from spotdl.const import log, TAG_PRESET, M4A_TAG_PRESET
 
 import urllib.request
 from logzero import logger as log

--- a/spotdl/metadata.py
+++ b/spotdl/metadata.py
@@ -187,11 +187,11 @@ class EmbedMetadata:
             audiofile[preset["genre"]] = meta_tags["genre"]
         if meta_tags["copyright"]:
             audiofile[preset["copyright"]] = meta_tags["copyright"]
-        if self.music_file.endswith((".flac", ".oga", ".ogg")):
+        if self.music_file.endswith((".flac", ".opus", ".ogg")):
             audiofile[preset["discnumber"]] = str(meta_tags["disc_number"])
         else:
             audiofile[preset["discnumber"]] = [(meta_tags["disc_number"], 0)]
-        if self.music_file.endswith((".flac", ".oga", ".ogg")):
+        if self.music_file.endswith((".flac", ".opus", ".ogg")):
             audiofile[preset["tracknumber"]] = str(meta_tags["track_number"])
         else:
             if preset["tracknumber"] == TAG_PRESET["tracknumber"]:

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -135,26 +135,6 @@ class TestFFmpeg:
         )
         assert " ".join(command) == expect_command
 
-    def test_convert_from_webm_to_ogg(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a copy -b:a 192k -vn {0}.ogg".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".webm", filename_fixture + ".ogg", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
-    def test_convert_from_webm_to_oga(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.oga".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".webm", filename_fixture + ".oga", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:v copy -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -182,26 +162,6 @@ class TestFFmpeg:
         monkeypatch.setattr("os.remove", lambda x: None)
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".flac", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
-    def test_convert_from_m4a_to_ogg(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -ar 48000 -vbr on -b:a 192k -vn {0}.ogg".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".m4a", filename_fixture + ".ogg", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
-    def test_convert_from_m4a_to_oga(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.oga".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".m4a", filename_fixture + ".oga", const.args.folder
         )
         assert " ".join(command) == expect_command
 

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
-
+ 
 from spotdl import const
 from spotdl import internals
 from spotdl import spotify_tools
@@ -8,12 +8,12 @@ from spotdl import youtube_tools
 from spotdl import convert
 from spotdl import metadata
 from spotdl import downloader
-
+ 
 import pytest
 import loader
-
+ 
 loader.load_defaults()
-
+ 
 SPOTIFY_TRACK_URL = "https://open.spotify.com/track/3SipFlNddvL0XNZRLXvdZD"
 EXPECTED_YOUTUBE_TITLE = "Janji - Heroes Tonight (feat. Johnning) [NCS Release]"
 EXPECTED_SPOTIFY_TITLE = "Janji - Heroes Tonight"
@@ -21,38 +21,38 @@ EXPECTED_YOUTUBE_URL = "http://youtube.com/watch?v=3nQNiWdeH2Q"
 # GIST_URL is the monkeypatched version of: https://www.youtube.com/results?search_query=janji+-+heroes
 # so that we get same results even if YouTube changes the list/order of videos on their page.
 GIST_URL = "https://gist.githubusercontent.com/ritiek/e731338e9810e31c2f00f13c249a45f5/raw/c11a27f3b5d11a8d082976f1cdd237bd605ec2c2/search_results.html"
-
-
+ 
+ 
 def pytest_namespace():
     # XXX: We override the value of `content_fixture` later in the tests.
     # We do not use an acutal @pytest.fixture because it does not accept
     # the monkeypatch parameter and we need to monkeypatch the network
     # request before creating the Pafy object.
     return {"content_fixture": None}
-
-
+ 
+ 
 @pytest.fixture(scope="module")
 def metadata_fixture():
     meta_tags = spotify_tools.generate_metadata(SPOTIFY_TRACK_URL)
     return meta_tags
-
-
+ 
+ 
 def test_metadata(metadata_fixture):
     expect_number = 24
     assert len(metadata_fixture) == expect_number
-
-
+ 
+ 
 class TestFileFormat:
     def test_with_spaces(self, metadata_fixture):
         title = internals.format_string(const.args.file_format, metadata_fixture)
         assert title == EXPECTED_SPOTIFY_TITLE
-
+ 
     def test_without_spaces(self, metadata_fixture):
         const.args.no_spaces = True
         title = internals.format_string(const.args.file_format, metadata_fixture)
         assert title == EXPECTED_SPOTIFY_TITLE.replace(" ", "_")
-
-
+ 
+ 
 def test_youtube_url(metadata_fixture, monkeypatch):
     monkeypatch.setattr(
         youtube_tools.GenerateYouTubeURL,
@@ -61,8 +61,8 @@ def test_youtube_url(metadata_fixture, monkeypatch):
     )
     url = youtube_tools.generate_youtube_url(SPOTIFY_TRACK_URL, metadata_fixture)
     assert url == EXPECTED_YOUTUBE_URL
-
-
+ 
+ 
 def test_youtube_title(metadata_fixture, monkeypatch):
     monkeypatch.setattr(
         youtube_tools.GenerateYouTubeURL,
@@ -73,15 +73,15 @@ def test_youtube_title(metadata_fixture, monkeypatch):
     pytest.content_fixture = content
     title = youtube_tools.get_youtube_title(content)
     assert title == EXPECTED_YOUTUBE_TITLE
-
-
+ 
+ 
 @pytest.fixture(scope="module")
 def filename_fixture(metadata_fixture):
     songname = internals.format_string(const.args.file_format, metadata_fixture)
     filename = internals.sanitize_title(songname)
     return filename
-
-
+ 
+ 
 def test_check_track_exists_before_download(tmpdir, metadata_fixture, filename_fixture):
     expect_check = False
     const.args.folder = str(tmpdir)
@@ -89,8 +89,8 @@ def test_check_track_exists_before_download(tmpdir, metadata_fixture, filename_f
     track_existence = downloader.CheckExists(filename_fixture, metadata_fixture)
     check = track_existence.already_exists(SPOTIFY_TRACK_URL)
     assert check == expect_check
-
-
+ 
+ 
 class TestDownload:
     def blank_audio_generator(self, filepath):
         if filepath.endswith(".m4a"):
@@ -98,22 +98,22 @@ class TestDownload:
         elif filepath.endswith(".webm"):
             cmd = "ffmpeg -f lavfi -i anullsrc -t 1 -c:a libopus {}".format(filepath)
         subprocess.call(cmd.split(" "))
-
+ 
     def test_m4a(self, monkeypatch, filename_fixture):
         expect_download = True
         monkeypatch.setattr("pafy.backend_shared.BaseStream.download", self.blank_audio_generator)
         monkeypatch.setattr("pafy.backend_youtube_dl.YtdlStream.download", self.blank_audio_generator)
         download = youtube_tools.download_song(filename_fixture + ".m4a", pytest.content_fixture)
         assert download == expect_download
-
+ 
     def test_webm(self, monkeypatch, filename_fixture):
         expect_download = True
         monkeypatch.setattr("pafy.backend_shared.BaseStream.download", self.blank_audio_generator)
         monkeypatch.setattr("pafy.backend_youtube_dl.YtdlStream.download", self.blank_audio_generator)
         download = youtube_tools.download_song(filename_fixture + ".webm", pytest.content_fixture)
         assert download == expect_download
-
-
+ 
+ 
 class TestFFmpeg:
     def test_convert_from_webm_to_mp3(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(
@@ -124,7 +124,7 @@ class TestFFmpeg:
             filename_fixture + ".webm", filename_fixture + ".mp3", const.args.folder
         )
         assert " ".join(command) == expect_command
-
+ 
     def test_convert_from_webm_to_m4a(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -cutoff 20000 -codec:a aac -ar 44100 -b:a 192k -vn {0}.m4a".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -134,17 +134,7 @@ class TestFFmpeg:
             filename_fixture + ".webm", filename_fixture + ".m4a", const.args.folder
         )
         assert " ".join(command) == expect_command
-
-    def test_convert_from_webm_to_vorbis(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".webm", filename_fixture + ".ogg", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
+ 
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:v copy -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -154,7 +144,7 @@ class TestFFmpeg:
             filename_fixture + ".m4a", filename_fixture + ".mp3", const.args.folder
         )
         assert " ".join(command) == expect_command
-
+ 
     def test_convert_from_m4a_to_webm(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -vbr on -b:a 192k -vn {0}.webm".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -164,7 +154,7 @@ class TestFFmpeg:
             filename_fixture + ".m4a", filename_fixture + ".webm", const.args.folder
         )
         assert " ".join(command) == expect_command
-
+ 
     def test_convert_from_m4a_to_flac(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a flac -ar 44100 -b:a 192k -vn {0}.flac".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -174,27 +164,7 @@ class TestFFmpeg:
             filename_fixture + ".m4a", filename_fixture + ".flac", const.args.folder
         )
         assert " ".join(command) == expect_command
-
-    def test_convert_from_m4a_to_opus(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -ar 48000 -vbr on -b:a 192k -vn {0}.opus".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".m4a", filename_fixture + ".opus", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
-    def test_convert_from_m4a_to_vorbis(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".m4a", filename_fixture + ".ogg", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
+ 
     def test_correct_container_for_m4a(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a.temp -acodec copy -b:a 192k -vn {0}.m4a".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -203,8 +173,8 @@ class TestFFmpeg:
             filename_fixture + ".m4a", filename_fixture + ".m4a", const.args.folder
         )
         assert " ".join(command) == expect_command
-
-
+ 
+ 
 class TestAvconv:
     @pytest.mark.skip(reason="avconv is no longer provided with FFmpeg")
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
@@ -219,39 +189,39 @@ class TestAvconv:
             avconv=True,
         )
         assert " ".join(command) == expect_command
-
-
+ 
+ 
 @pytest.fixture(scope="module")
 def trackpath_fixture(filename_fixture):
     trackpath = os.path.join(const.args.folder, filename_fixture)
     return trackpath
-
-
+ 
+ 
 class TestEmbedMetadata:
     def test_embed_in_mp3(self, metadata_fixture, trackpath_fixture):
         expect_embed = True
         embed = metadata.embed(trackpath_fixture + ".mp3", metadata_fixture)
         assert embed == expect_embed
-
+ 
     def test_embed_in_m4a(self, metadata_fixture, trackpath_fixture):
         expect_embed = True
         embed = metadata.embed(trackpath_fixture + ".m4a", metadata_fixture)
         os.remove(trackpath_fixture + ".m4a")
         assert embed == expect_embed
-
+ 
     def test_embed_in_webm(self, metadata_fixture, trackpath_fixture):
         expect_embed = False
         embed = metadata.embed(trackpath_fixture + ".webm", metadata_fixture)
         os.remove(trackpath_fixture + ".webm")
         assert embed == expect_embed
-
+ 
     def test_embed_in_flac(self, metadata_fixture, trackpath_fixture):
         expect_embed = True
         embed = metadata.embed(trackpath_fixture + ".flac", metadata_fixture)
         os.remove(trackpath_fixture + ".flac")
         assert embed == expect_embed
-
-
+ 
+ 
 def test_check_track_exists_after_download(
     metadata_fixture, filename_fixture, trackpath_fixture
 ):
@@ -260,3 +230,4 @@ def test_check_track_exists_after_download(
     check = track_existence.already_exists(SPOTIFY_TRACK_URL)
     os.remove(trackpath_fixture + ".mp3")
     assert check == expect_check
+ 

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -135,6 +135,26 @@ class TestFFmpeg:
         )
         assert " ".join(command) == expect_command
 
+    def test_convert_from_webm_to_ogg(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a copy -b:a 192k -vn {0}.ogg".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".webm", filename_fixture + ".ogg", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_webm_to_oga(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.oga".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".webm", filename_fixture + ".oga", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:v copy -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -162,6 +182,26 @@ class TestFFmpeg:
         monkeypatch.setattr("os.remove", lambda x: None)
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".flac", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_m4a_to_ogg(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -ar 48000 -vbr on -b:a 192k -vn {0}.ogg".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".ogg", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_m4a_to_oga(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.oga".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".oga", const.args.folder
         )
         assert " ".join(command) == expect_command
 

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -165,6 +165,26 @@ class TestFFmpeg:
         )
         assert " ".join(command) == expect_command
  
+    def test_convert_from_m4a_to_opus(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -ar 48000 -vbr on -b:a 192k -vn {0}.opus".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".opus", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+ 
+    def test_convert_from_m4a_to_vorbis(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".ogg", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+ 
     def test_correct_container_for_m4a(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a.temp -acodec copy -b:a 192k -vn {0}.m4a".format(
             os.path.join(const.args.folder, filename_fixture)

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -135,16 +135,6 @@ class TestFFmpeg:
         )
         assert " ".join(command) == expect_command
 
-    def test_convert_from_webm_to_opus(self, filename_fixture, monkeypatch):
-        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a copy -b:a 192k -vn {0}.opus".format(
-            os.path.join(const.args.folder, filename_fixture)
-        )
-        monkeypatch.setattr("os.remove", lambda x: None)
-        _, command = convert.song(
-            filename_fixture + ".webm", filename_fixture + ".opus", const.args.folder
-        )
-        assert " ".join(command) == expect_command
-
     def test_convert_from_webm_to_vorbis(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
             os.path.join(const.args.folder, filename_fixture)

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -135,6 +135,26 @@ class TestFFmpeg:
         )
         assert " ".join(command) == expect_command
 
+    def test_convert_from_webm_to_opus(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a copy -b:a 192k -vn {0}.opus".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".webm", filename_fixture + ".opus", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_webm_to_vorbis(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.webm -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".webm", filename_fixture + ".ogg", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
         expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:v copy -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(
             os.path.join(const.args.folder, filename_fixture)
@@ -162,6 +182,26 @@ class TestFFmpeg:
         monkeypatch.setattr("os.remove", lambda x: None)
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".flac", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_m4a_to_opus(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libopus -ar 48000 -vbr on -b:a 192k -vn {0}.opus".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".opus", const.args.folder
+        )
+        assert " ".join(command) == expect_command
+
+    def test_convert_from_m4a_to_vorbis(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -hide_banner -nostats -v panic -i {0}.m4a -codec:a libvorbis -ar 44100 -b:a 192k -vn {0}.ogg".format(
+            os.path.join(const.args.folder, filename_fixture)
+        )
+        monkeypatch.setattr("os.remove", lambda x: None)
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".ogg", const.args.folder
         )
         assert " ".join(command) == expect_command
 


### PR DESCRIPTION
For Opus, use the `.ogg` output extension. For Vorbis, use `.oga`.

See \#291 

Edit: actually, now use `.opus` for Opus and `.ogg` for Vorbis, to match standards better. 