### PR TITLE
Trim silence at the beginning of a song

### DIFF
--- a/core/convert.py
+++ b/core/convert.py
@@ -75,6 +75,7 @@ class Converter:
 
         # add common params for any of the above combination
         ffmpeg_params += '-b:a 192k -vn '
+        ffmpeg_params += '-af silenceremove=start_periods=1 '
         ffmpeg_pre += ' -i'
         command = ffmpeg_pre.split() + [self.input_file] + ffmpeg_params.split() + [self.output_file]
 

--- a/core/convert.py
+++ b/core/convert.py
@@ -15,7 +15,7 @@ https://trac.ffmpeg.org/wiki/Encode/AAC
 """
 
 
-def song(input_song, output_song, folder, avconv=False, trim_silence=True):
+def song(input_song, output_song, folder, avconv=False, trim_silence=False):
     """ Do the audio format conversion. """
     if input_song == output_song:
         return 0
@@ -30,7 +30,7 @@ def song(input_song, output_song, folder, avconv=False, trim_silence=True):
 
 
 class Converter:
-    def __init__(self, input_song, output_song, folder, trim_silence):
+    def __init__(self, input_song, output_song, folder, trim_silence=False):
         self.input_file = os.path.join(folder, input_song)
         self.output_file = os.path.join(folder, output_song)
         self.trim_silence = trim_silence

--- a/core/convert.py
+++ b/core/convert.py
@@ -15,11 +15,11 @@ https://trac.ffmpeg.org/wiki/Encode/AAC
 """
 
 
-def song(input_song, output_song, folder, avconv=False):
+def song(input_song, output_song, folder, avconv=False, trim_silence=True):
     """ Do the audio format conversion. """
     if input_song == output_song:
         return 0
-    convert = Converter(input_song, output_song, folder)
+    convert = Converter(input_song, output_song, folder, trim_silence)
     log.info('Converting {0} to {1}'.format(
         input_song, output_song.split('.')[-1]))
     if avconv:
@@ -30,9 +30,10 @@ def song(input_song, output_song, folder, avconv=False):
 
 
 class Converter:
-    def __init__(self, input_song, output_song, folder):
+    def __init__(self, input_song, output_song, folder, trim_silence):
         self.input_file = os.path.join(folder, input_song)
         self.output_file = os.path.join(folder, output_song)
+        self.trim_silence = trim_silence
 
     def with_avconv(self):
         if log.level == 10:
@@ -43,7 +44,10 @@ class Converter:
         command = ['avconv', '-loglevel', level, '-i',
                    self.input_file, '-ab', '192k',
                    self.output_file, '-y']
-
+        
+        if self.trim_silence:
+            log.warning('--trim-silence not supported with avconv')
+        
         log.debug(command)
         return subprocess.call(command)
 
@@ -75,8 +79,11 @@ class Converter:
 
         # add common params for any of the above combination
         ffmpeg_params += '-b:a 192k -vn '
-        ffmpeg_params += '-af silenceremove=start_periods=1 '
         ffmpeg_pre += ' -i'
+        
+        if self.trim_silence:
+            ffmpeg_params += '-af silenceremove=start_periods=1 '
+        
         command = ffmpeg_pre.split() + [self.input_file] + ffmpeg_params.split() + [self.output_file]
 
         log.debug(command)

--- a/core/handle.py
+++ b/core/handle.py
@@ -77,6 +77,7 @@ def override_config(config_file, parser, raw_args=None):
     parser.set_defaults(overwrite=config['overwrite'])
     parser.set_defaults(input_ext=config['input-ext'])
     parser.set_defaults(output_ext=config['output-ext'])
+    parser.set_defaults(trim_silence=config['trim-silence'])
     parser.set_defaults(download_only_metadata=config['download-only-metadata'])
     parser.set_defaults(dry_run=config['dry-run'])
     parser.set_defaults(music_videos_only=config['music-videos-only'])

--- a/core/handle.py
+++ b/core/handle.py
@@ -20,6 +20,7 @@ default_conf = { 'spotify-downloader':
                    'overwrite'              : 'prompt',
                    'input-ext'              : '.m4a',
                    'output-ext'             : '.mp3',
+                   'trim-silence'           : False,
                    'download-only-metadata' : False,
                    'dry-run'                : False,
                    'music-videos-only'      : False,
@@ -153,6 +154,10 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         help='file format to save the downloaded track with, each tag '
              'is surrounded by curly braces. Possible formats: '
              '{}'.format([internals.formats[x] for x in internals.formats]))
+    parser.add_argument(
+        '--trim-silence', default=config['trim-silence'],
+        help='remove silence from the start of the audio',
+        action='store_true')
     parser.add_argument(
         '-sf', '--search-format', default=config['search-format'],
         help='search format to search for on YouTube, each tag '

--- a/spotdl.py
+++ b/spotdl.py
@@ -159,7 +159,7 @@ def download_single(raw_song, number=None):
             print('')
             try:
                 convert.song(input_song, output_song, const.args.folder,
-                             avconv=const.args.avconv)
+                             avconv=const.args.avconv, trim_silence=const.args.trim_silence)
             except FileNotFoundError:
                 encoder = 'avconv' if const.args.avconv else 'ffmpeg'
                 log.warning('Could not find {0}, skipping conversion'.format(encoder))


### PR DESCRIPTION
FFmpeg offers a way to trim silences at the beginning and at the end of an audio (even though the latter doesn't seem to be working right now).

Since spotify-downloader already uses ffmpeg for the conversion, it was very easy to add.
I think there could even be an option to turn this behavior on or off, which I can implement if needed