### PR TITLE
--playlist now starts downloading straight away

### DIFF
--- a/core/spotify_tools.py
+++ b/core/spotify_tools.py
@@ -136,8 +136,8 @@ def write_playlist(playlist_url, text_file=None):
     tracks = playlist['tracks']
     if not text_file:
         text_file = u'{0}.txt'.format(slugify(playlist['name'], ok='-_()[]{}'))
-    return write_tracks(tracks, text_file)
-
+    write_tracks(tracks, text_file)
+    return text_file
 
 def fetch_album(album):
     splits = internals.get_splits(album)

--- a/spotdl.py
+++ b/spotdl.py
@@ -175,7 +175,6 @@ def download_single(raw_song, number=None):
 
 def main():
     const.args = handle.get_arguments()
-
     if const.args.version:
         print('spotdl {version}'.format(version=__version__))
         sys.exit()
@@ -197,7 +196,7 @@ def main():
         elif const.args.list:
             download_list(text_file=const.args.list)
         elif const.args.playlist:
-            spotify_tools.write_playlist(playlist_url=const.args.playlist)
+            download_list(text_file=spotify_tools.write_playlist(playlist_url=const.args.playlist))
         elif const.args.album:
             spotify_tools.write_album(album_url=const.args.album)
         elif const.args.username:


### PR DESCRIPTION
It felt weird how you had to run ``--playlist`` and then ``--list``. This alteration simply makes the script write the file, and then start downloading straight away, without the user having to run a second command.