### PR TITLE
Move default `config.yml` to .config folder

### DIFF
--- a/core/handle.py
+++ b/core/handle.py
@@ -1,3 +1,4 @@
+import appdirs
 from core import internals, const
 
 log = const.log
@@ -79,7 +80,9 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     if to_merge:
-        config_file = os.path.join(sys.path[0], 'config.yml')
+        config_dir = os.path.join(appdirs.user_config_dir(), 'spotdl')
+        os.makedirs(config_dir, exist_ok=True)
+        config_file = os.path.join(config_dir, 'config.yml')
         config = merge(default_conf['spotify-downloader'], get_config(config_file))
     else:
         config = default_conf['spotify-downloader']
@@ -175,8 +178,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         help=argparse.SUPPRESS)
     parser.add_argument(
         '-c', '--config', default=None,
-        help='path to config.yml file (otherwise load it from same '
-             'directory as spotdl.py)')
+        help='path to custom config.yml file')
 
     parsed = parser.parse_args(raw_args)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ titlecase >= 0.10.0
 logzero >= 1.3.1
 lyricwikia >= 0.1.8
 PyYAML >= 3.12
+appdirs >= 1.4.3

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'titlecase >= 0.10.0',
         'logzero >= 1.3.1',
         'lyricwikia >= 0.1.8',
-        'PyYAML >= 3.12'
+        'PyYAML >= 3.12',
+        'appdirs >= 1.4.3'
     ],
     description='Download songs from YouTube using Spotify song URLs or playlists with albumart and meta-tags.',
     long_description=long_description,


### PR DESCRIPTION
This will be useful when installing from `setup.py` otherwise `config.yml` will end up in weird locations like `/usr/bin/` and like where there are supposed to be all binary files.

With this PR, default `config.yml` will be generated in `os.path.join(home_dir, '.config', 'spotdl', 'config.yml')` on both Windows and Linux machines.

We'll also need to update the [wiki](https://github.com/ritiek/spotify-downloader/wiki/Advanced-usage#config-file) if this gets merged.
