### PR TITLE
Generate m3u playlist file from a text file containing tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config.yml
 Music/
 *.txt
+*.m3u
 upload.sh
 .pytest_cache/
 

--- a/core/handle.py
+++ b/core/handle.py
@@ -108,6 +108,11 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
             action='store_true')
 
     parser.add_argument(
+        '--write-m3u',
+        help="generate an .m3u playlist file with youtube links given "
+             "a text file containing tracks",
+        action='store_true')
+    parser.add_argument(
         '-m', '--manual', default=config['manual'],
         help='choose the track to download manually from a list '
              'of matching tracks',
@@ -182,6 +187,9 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
 
     if parsed.config is not None and to_merge:
         parsed = override_config(parsed.config, parser)
+
+    if parsed.write_m3u and not parsed.list:
+        parser.error('--write-m3u can only be used with --list')
 
     parsed.log_level = log_leveller(parsed.log_level)
 

--- a/core/internals.py
+++ b/core/internals.py
@@ -180,3 +180,16 @@ def get_music_dir():
     # respectively is sufficient.
     # On Linux, default to /home/<user>/Music if the above method failed.
     return os.path.join(home, 'Music')
+
+def read_tracks_from_file(track_file):
+    with open(track_file, 'r') as listed:
+        # read tracks into a list and remove any duplicates
+        tracks = listed.read().splitlines()
+        tracks = list(set(tracks))
+    # ignore blank lines in text_file (if any)
+    try:
+        tracks.remove('')
+    except ValueError:
+        pass
+
+    return tracks

--- a/core/youtube_tools.py
+++ b/core/youtube_tools.py
@@ -75,7 +75,7 @@ def generate_m3u(track_file):
                                 total_tracks,
                                 content.watchv_url))
             log.debug(track)
-            m3u_key = '#EXTM3U:{duration},{title}\n{youtube_url}\n'.format(
+            m3u_key = '#EXTINF:{duration},{title}\n{youtube_url}\n'.format(
                                 duration=internals.get_sec(content.duration),
                                 title=content.title,
                                 youtube_url=content.watchv_url)

--- a/core/youtube_tools.py
+++ b/core/youtube_tools.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 import urllib
 import pafy
+from slugify import slugify
 
 from core import spotify_tools
 from core import internals

--- a/test/test_handle.py
+++ b/test/test_handle.py
@@ -1,12 +1,22 @@
 import yaml
 
 from core import handle
-from core import const
 
 import pytest
 import os
 import sys
 import argparse
+
+
+def test_error_m3u_without_list():
+    with pytest.raises(SystemExit):
+        handle.get_arguments(raw_args=('-s cool song', '--write-m3u',),
+                             to_group=True)
+
+
+def test_m3u_with_list():
+    handle.get_arguments(raw_args=('-l cool_list.txt', '--write-m3u',),
+                         to_group=True)
 
 
 def test_log_str_to_int():

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -43,17 +43,20 @@ def test_album(tmpdir):
 def test_m3u(tmpdir):
     expect_m3u = ('#EXTM3U\n\n'
                   '#EXTINF:198,Tobu - Candyland [NCS Release]\n'
-                  'http://www.youtube.com/watch?v=IIrCDAV3EgI\n')
+                  'http://www.youtube.com/watch?v=IIrCDAV3EgI\n'
+                  '#EXTINF:226,Alan Walker - Spectre [NCS Release]\n'
+                  'http://www.youtube.com/watch?v=AOeY-nDp7hI\n')
 
     with open(text_file, 'r') as tin:
         tracks = tin.readlines()
 
-    single_song_file = os.path.join(str(tmpdir), 'test_m3u.txt')
-    with open(single_song_file, 'w') as tout:
+    m3u_track_file = os.path.join(str(tmpdir), 'm3u_test.txt')
+    with open(m3u_track_file, 'w') as tout:
         tout.write('\n'.join(tracks[:1]))
+        tout.write('\nhttp://www.youtube.com/watch?v=AOeY-nDp7hI')
 
-    youtube_tools.generate_m3u(single_song_file)
-    m3u_file = '{}.m3u'.format(single_song_file.split('.')[0])
+    youtube_tools.generate_m3u(m3u_track_file)
+    m3u_file = '{}.m3u'.format(m3u_track_file.split('.')[0])
     with open(m3u_file, 'r') as m3u_in:
         m3u = m3u_in.readlines()
 

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -1,10 +1,14 @@
 from core import spotify_tools
+from core import youtube_tools
 from core import const
 
 import spotdl
 
+import loader
 import builtins
 import os
+
+loader.load_defaults()
 
 
 def test_user_playlists(tmpdir, monkeypatch):
@@ -34,6 +38,24 @@ def test_album(tmpdir):
     with open(text_file, 'r') as tin:
         tracks = len(tin.readlines())
     assert tracks == expect_tracks
+
+
+def test_m3u(tmpdir):
+    expect_m3u = ('#EXTM3U\n\n'
+                  '#EXTM3U:226,Vidya Vidya - Safari Fruits [NCS Release]\n'
+                  'http://www.youtube.com/watch?v=PbIjuqd4ENY\n'
+                  '#EXTM3U:198,Tobu - Candyland [NCS Release]\n'
+                  'http://www.youtube.com/watch?v=IIrCDAV3EgI\n')
+    expect_lines = 6
+    with open(text_file, 'r') as tin:
+        tracks = tin.readlines()
+    with open(text_file, 'w') as tout:
+        tout.write('\n'.join(tracks[:2]))
+    youtube_tools.generate_m3u(text_file)
+    m3u_file = '{}.m3u'.format(text_file.split('.')[0])
+    with open(m3u_file, 'r') as m3u_in:
+        m3u = m3u_in.readlines()
+    assert ''.join(m3u) == expect_m3u
 
 
 def test_trim():

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -42,19 +42,21 @@ def test_album(tmpdir):
 
 def test_m3u(tmpdir):
     expect_m3u = ('#EXTM3U\n\n'
-                  '#EXTM3U:226,Vidya Vidya - Safari Fruits [NCS Release]\n'
-                  'http://www.youtube.com/watch?v=PbIjuqd4ENY\n'
-                  '#EXTM3U:198,Tobu - Candyland [NCS Release]\n'
+                  '#EXTINF:198,Tobu - Candyland [NCS Release]\n'
                   'http://www.youtube.com/watch?v=IIrCDAV3EgI\n')
-    expect_lines = 6
+
     with open(text_file, 'r') as tin:
         tracks = tin.readlines()
-    with open(text_file, 'w') as tout:
-        tout.write('\n'.join(tracks[:2]))
-    youtube_tools.generate_m3u(text_file)
-    m3u_file = '{}.m3u'.format(text_file.split('.')[0])
+
+    single_song_file = os.path.join(str(tmpdir), 'test_m3u.txt')
+    with open(single_song_file, 'w') as tout:
+        tout.write('\n'.join(tracks[:1]))
+
+    youtube_tools.generate_m3u(single_song_file)
+    m3u_file = '{}.m3u'.format(single_song_file.split('.')[0])
     with open(m3u_file, 'r') as m3u_in:
         m3u = m3u_in.readlines()
+
     assert ''.join(m3u) == expect_m3u
 
 


### PR DESCRIPTION
This PR adds an option `--write-m3u` which generates m3u playlist files with YouTube URLs given a text file containing tracks.

This command will match and write YouTube URLs to `track_file.m3u`:

```
$ python3 spotdl.py --list=track_file.txt --write-m3u
INFO: Generating track_file.m3u from 20 YouTube URLs
INFO: Matched track 1/30 (http://www.youtube.com/watch?v=DLfoHEOH_uc)
INFO: Matched track 2/30 (http://www.youtube.com/watch?v=owDiftkACDw)
INFO: Matched track 3/30 (http://www.youtube.com/watch?v=CDcfAPRYNhY)
...
```

I enforced this option to work only when `--list` is passed.

The generated `.m3u` looks like:
```
#EXTM3U

#EXTINF:211,Before You Exit - Soldier (Lyrics)
http://www.youtube.com/watch?v=IdE3HLDmVTA
#EXTINF:275,Jeff Basta & Caitlin Gilroy - Broken Heart (Official)
http://www.youtube.com/watch?v=CDcfAPRYNhY
```

and it works with mpv, mps-youtube, etc. players.