### PR TITLE
Add command line options for skip and successful file

### DIFF
--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -28,6 +28,8 @@ default_conf = { 'spotify-downloader':
                    'file-format'            : '{artist} - {track_name}',
                    'search-format'          : '{artist} - {track_name} lyrics',
                    'youtube-api-key'        : None,
+                   'skip'                   : None,
+                   'write-successful'       : None,
                    'log-level'              : 'INFO' }
                }
 
@@ -175,6 +177,12 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
     parser.add_argument(
         '-yk', '--youtube-api-key', default=config['youtube-api-key'],
         help=argparse.SUPPRESS)
+    parser.add_argument(
+        '-sk', '--skip', default=config['skip'],
+        help='path to file containing tracks to skip')
+    parser.add_argument(
+        '-w', '--write-successful', default=config['write-successful'],
+        help='path to file to write successful tracks to')
     parser.add_argument(
         '-c', '--config', default=None,
         help='path to custom config.yml file')

--- a/spotdl/spotdl.py
+++ b/spotdl/spotdl.py
@@ -209,7 +209,11 @@ def main():
         if const.args.song:
             download_single(raw_song=const.args.song)
         elif const.args.list:
-            download_list(tracks_file=const.args.list, skip_file=const.args.skip, write_successful_file=const.args.write_successful)
+            download_list(
+                tracks_file=const.args.list,
+                skip_file=const.args.skip,
+                write_successful_file=const.args.write_successful
+            )
         elif const.args.playlist:
             spotify_tools.write_playlist(playlist_url=const.args.playlist)
         elif const.args.album:

--- a/spotdl/spotdl.py
+++ b/spotdl/spotdl.py
@@ -105,7 +105,7 @@ def download_list(tracks_file, skip_file=None, write_successful_file=None):
             internals.trim_song(tracks_file)
             # and append it at the end of file
             with open(tracks_file, 'a') as f:
-                f.write(raw_song + '\n')
+                f.write('\n' + raw_song)
             log.warning('Failed to download song. Will retry after other songs\n')
             # wait 0.5 sec to avoid infinite looping
             time.sleep(0.5)
@@ -116,7 +116,7 @@ def download_list(tracks_file, skip_file=None, write_successful_file=None):
         log.debug('Adding downloaded song to write successful file')
         if write_successful_file is not None:
             with open(write_successful_file, 'a') as f:
-                f.write(raw_song + '\n')
+                f.write('\n' + raw_song)
         log.debug('Removing downloaded song from tracks file')
         internals.trim_song(tracks_file)
 


### PR DESCRIPTION
Closes #296.

Adding two command line flags: `-sk`/`--skip` and `-w`/`--write-successful`. Both have the same format, so using the same file with both flags is possible:

    spotdl -l playlist.txt -w skip.txt -sk skip.txt

I.e. successfully downloaded tracks will land in `skip.txt` and thus being skipped directly when creating and downloading the track file again.