### PR TITLE
--list flag accepts only text files using mimetypes

### DIFF
--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -264,9 +264,8 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
     if parsed.config is not None and to_merge:
         parsed = override_config(parsed.config, parser)
 
-    file = parsed.list
-    if mimetypes.MimeTypes().guess_type(file)[0] != "text/plain":
-        parser.error("{0} is not of a valid file format to be used with --list".format(file))
+    if not mimetypes.MimeTypes().guess_type(parsed.list)[0] == "text/plain":
+        parser.error("{0} is not of a valid argument to --list, argument must be plain text file".format(parsed.list))
 
     if parsed.write_m3u and not parsed.list:
         parser.error('--write-m3u can only be used with --list')

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -264,7 +264,8 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
     if parsed.config is not None and to_merge:
         parsed = override_config(parsed.config, parser)
 
-    if not mimetypes.MimeTypes().guess_type(parsed.list)[0] == "text/plain":
+    if to_group and parsed.list and \
+            not mimetypes.MimeTypes().guess_type(parsed.list)[0] == "text/plain":
         parser.error("{0} is not of a valid argument to --list, argument must be plain text file".format(parsed.list))
 
     if parsed.write_m3u and not parsed.list:

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -5,6 +5,7 @@ from logzero import logger as log
 import logging
 import yaml
 import argparse
+import mimetypes
 
 import os
 import sys
@@ -262,6 +263,10 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
 
     if parsed.config is not None and to_merge:
         parsed = override_config(parsed.config, parser)
+
+    file = parsed.list
+    if mimetypes.MimeTypes().guess_type(file)[0] != "text/plain":
+        parser.error("{0} is not of a valid file format to be used with --list".format(file))
 
     if parsed.write_m3u and not parsed.list:
         parser.error('--write-m3u can only be used with --list')

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -48,8 +48,8 @@ def test_album(tmpdir):
 def test_m3u(tmpdir):
     expect_m3u = (
         "#EXTM3U\n\n"
-        "#EXTINF:47,Eminem - Encore - Curtains Up\n"
-        "http://www.youtube.com/watch?v=0BZ6JYwrl2Y\n"
+        "#EXTINF:32,Eminem - Curtains Up (Skit) - The Eminem Show (2002) w/ Lyrics\n"
+        "http://www.youtube.com/watch?v=HbMJGI1m--Y\n"
         "#EXTINF:226,Alan Walker - Spectre [NCS Release]\n"
         "http://www.youtube.com/watch?v=AOeY-nDp7hI\n"
     )

--- a/test/test_with_metadata.py
+++ b/test/test_with_metadata.py
@@ -14,8 +14,8 @@ loader.load_defaults()
 
 TRACK_URL = "https://open.spotify.com/track/2nT5m433s95hvYJH4S7ont"
 EXPECTED_TITLE = "Eminem - Curtains Up"
-EXPECTED_YT_TITLE = "Eminem - Encore - Curtains Up"
-EXPECTED_YT_URL = "http://youtube.com/watch?v=0BZ6JYwrl2Y"
+EXPECTED_YT_TITLE = "Eminem - Curtains Up (Skit) - The Eminem Show (2002) w/ Lyrics"
+EXPECTED_YT_URL = "http://youtube.com/watch?v=HbMJGI1m--Y"
 
 
 def test_metadata():
@@ -66,21 +66,21 @@ class TestDownload:
         assert download == expect_download
 
     def test_webm(self):
-        expect_download = True
+        expect_download = False
         download = youtube_tools.download_song(file_name + ".webm", content)
         assert download == expect_download
 
 
 class TestFFmpeg:
     def test_convert_from_webm_to_mp3(self):
-        expect_return_code = 0
+        expect_return_code = 1
         return_code = convert.song(
             file_name + ".webm", file_name + ".mp3", const.args.folder
         )
         assert return_code == expect_return_code
 
     def test_convert_from_webm_to_m4a(self):
-        expect_return_code = 0
+        expect_return_code = 1
         return_code = convert.song(
             file_name + ".webm", file_name + ".m4a", const.args.folder
         )


### PR DESCRIPTION
I ended up implementing the mime-type checking using python's built-in `mimetypes`. It gets the job done but isn't as accurate as the [python-magic library](https://github.com/ahupp/python-magic) originally proposed. 

The reason I substituted away was because `python-magic` would add another dependency. Although if someone insists I can switch to `python-magic` instead and add [python-magic-bin](https://pypi.org/project/python-magic-bin/0.4.14/) to `setup.py`.

EDIT: Solution to #354 