### PR TITLE
Fix YouTube tests from failing yet again (hopefully)

### DIFF
--- a/spotdl/youtube_tools.py
+++ b/spotdl/youtube_tools.py
@@ -75,6 +75,8 @@ def generate_m3u(track_file):
     log.info("Generating {0} from {1} YouTube URLs".format(target_file, total_tracks))
     with open(target_file, "w") as output_file:
         output_file.write("#EXTM3U\n\n")
+
+    videos = []
     for n, track in enumerate(tracks, 1):
         content, _ = match_video_and_metadata(track)
         if content is None:
@@ -94,6 +96,9 @@ def generate_m3u(track_file):
             log.debug(m3u_key)
             with open(target_file, "a") as output_file:
                 output_file.write(m3u_key)
+            videos.append(content)
+
+    return videos
 
 
 def download_song(file_name, content):

--- a/spotdl/youtube_tools.py
+++ b/spotdl/youtube_tools.py
@@ -70,7 +70,7 @@ def get_youtube_title(content, number=None):
 
 def generate_m3u(track_file):
     tracks = internals.get_unique_tracks(track_file)
-    target_file = "{}.m3u".format(track_file.split(".")[0])
+    target_file = "{}.m3u".format(os.path.splitext(track_file)[0])
     total_tracks = len(tracks)
     log.info("Generating {0} from {1} YouTube URLs".format(target_file, total_tracks))
     with open(target_file, "w") as output_file:

--- a/test/loader.py
+++ b/test/loader.py
@@ -1,3 +1,7 @@
+import pafy
+
+from spotdl import youtube_tools
+from spotdl import spotify_tools
 from spotdl import const
 from spotdl import handle
 from spotdl import spotdl
@@ -14,3 +18,13 @@ def load_defaults():
     spotdl.log = const.logzero.setup_logger(
         formatter=const._formatter, level=const.args.log_level
     )
+
+
+def match_url_in_search_results(url, raw_song):
+    metadata = spotify_tools.generate_metadata(raw_song)
+    url_fetcher = youtube_tools.GenerateYouTubeURL(raw_song, metadata)
+    video_info = url_fetcher.scrape(bestmatch=False)
+    for video in video_info:
+        if video["link"] in url:
+            return video
+    assert (False, "Could not match generated YouTube URL from expected YouTube URLs")

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -59,7 +59,7 @@ def test_m3u(tmpdir):
         track_file.write("\n" + test_youtube_track)
 
     first_video, *_ = youtube_tools.generate_m3u(m3u_track_file)
-    m3u_file = "{}.m3u".format(m3u_track_file.split(".")[0])
+    m3u_file = "{}.m3u".format(os.path.splitext(m3u_track_file)[0])
 
     with open(m3u_file, "r") as m3u_in:
         m3u_content = m3u_in.readlines()

--- a/test/test_with_metadata.py
+++ b/test/test_with_metadata.py
@@ -1,5 +1,3 @@
-import os
-
 from spotdl import const
 from spotdl import internals
 from spotdl import spotify_tools
@@ -9,6 +7,11 @@ from spotdl import metadata
 from spotdl import downloader
 
 import loader
+
+import pytest
+import os
+import subprocess
+
 
 loader.load_defaults()
 
@@ -74,6 +77,13 @@ class TestDownload:
         assert download == expect_download
 
 
+def check_ffmpeg_codec_support(codec):
+    process = subprocess.Popen(['ffmpeg'], stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    has_codec = "--enable-{}".format(codec) in stderr.decode('utf-8')
+    return has_codec
+
+
 class TestFFmpeg:
     def test_convert_from_webm_to_mp3(self):
         expect_return_code = 0
@@ -82,6 +92,8 @@ class TestFFmpeg:
         )
         assert return_code == expect_return_code
 
+    @pytest.mark.skipif(not check_ffmpeg_codec_support('libfdk-aac'),
+                        reason='FFmpeg has not been compiled with libfdk-aac support')
     def test_convert_from_webm_to_m4a(self):
         expect_return_code = 0
         return_code = convert.song(


### PR DESCRIPTION
Instead of exactly matching the YouTube video and its rank in results, it will now check whether the video exists anywhere in the first page of the results.

This is still a weird approach since we do not hardcode the expected YouTube video URL in the tests and instead we use additional code to check whether the generated video URL exists in the results first page.

Anyway, IMO this shouldn't break as frequently as before (if not at all). We'll only know this with time though.

By the way, since installing FFmpeg from apt does not come pre-compiled with `libfdk-aac` support, so `test_convert_from_webm_to_m4a` would end up failing. I've set pytest to skip this particular test in such a case.