### PR TITLE
Import spotipy in downloader.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Refactored core downloading module ([@ritiek](https://github.com/ritiek)) (#410)
 
+### Fixed
+- Included a missing `import spotipy` in downloader.py ([@ritiek](https://github.com/ritiek)) (#440)
+
 ## [1.1.0] - 2018-11-13
 ### Added
 - Output error details when track download fails from list file ([@ManveerBasra](https://github.com/ManveerBasra)) (#406)

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -5,6 +5,7 @@ from spotdl import internals
 from spotdl import spotify_tools
 from spotdl import youtube_tools
 
+import spotipy
 from logzero import logger as log
 import os
 


### PR DESCRIPTION
Fixes a missing `import spotipy` which is being used in catching an exception. https://github.com/ritiek/spotify-downloader/blob/eae9316cee23dc6f209e710c9a2d508170ba6327/spotdl/downloader.py#L210