### PR TITLE
Pass multiple tracks at once in --song argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Ability to pass multiple tracks with `-s` option ([@ritiek](https://github.com/ritiek)) (#442)
+
 ### Changed
 - Refactored core downloading module ([@ritiek](https://github.com/ritiek)) (#410)
 

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -99,7 +99,10 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         group = parser.add_mutually_exclusive_group(required=True)
 
         group.add_argument(
-            "-s", "--song", help="download track by spotify link or name"
+            "-s",
+            "--song",
+            nargs='+',
+            help="download track by spotify link or name"
         )
         group.add_argument("-l", "--list", help="download tracks from a file")
         group.add_argument(

--- a/spotdl/spotdl.py
+++ b/spotdl/spotdl.py
@@ -22,8 +22,9 @@ def debug_sys_info():
 
 def match_args():
     if const.args.song:
-        track_dl = downloader.Downloader(raw_song=const.args.song)
-        track_dl.download_single()
+        for track in const.args.song:
+            track_dl = downloader.Downloader(raw_song=track)
+            track_dl.download_single()
     elif const.args.list:
         if const.args.write_m3u:
             youtube_tools.generate_m3u(track_file=const.args.list)


### PR DESCRIPTION
Closes #412. Allows us to do things like:
```
$ spotdl -s "track one" "track two"
```
so we could quickly download a small number of tracks without first having to enter them in a file or having to wait for each track download to complete before running a similar command for the next track.

One thing I am worried about is that with this PR `-s` argument accepts more than one parameter. So command-line newbies might attempt to download tracks without giving importance to surrounding the argument in quotes and be surprised with the results. For example:
```
$ spotdl -s ncs - spectre
```
won't error out and the tool would apparently try downloading 3 different tracks: "ncs", "-" and "spectre" which makes no sense.

The argument needs to be surrounded in quotes for expected results:
```
$ spotdl -s "ncs - spectre"
```