### PR TITLE
Remove question links from FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ contains detailed information about different available ways to download tracks.
 
 ## FAQ
 
-- [
-How to specify a custom folder where tracks should be downloaded?](https://github.com/ritiek/spotify-downloader/wiki/FAQ#how-to-specify-a-custom-folder-where-tracks-should-be-downloaded)
-
-Check out our [FAQ wiki page](https://github.com/ritiek/spotify-downloader/wiki/FAQ)
-for more info.
+All FAQs will be mentioned in our [FAQ wiki page](https://github.com/ritiek/spotify-downloader/wiki/FAQ).
 
 ## Contributing
 


### PR DESCRIPTION
It isn't practical to update the README for every question in the wiki page. Let's just remove the questions and just link to the FAQ page.