### PR TITLE
Fix conversion conflicts when both input and output filenames are same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+# Spotdl generated files
+*.m4a
+*.mp3
 config.yml
 Music/
 *.txt
 *.m3u
-upload.sh
 .pytest_cache/
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refactored core downloading module ([@ritiek](https://github.com/ritiek)) (#410)
 
 ### Fixed
+- Workaround conversion conflicts when input and output filename are same ([@ritiek](https://github.com/ritiek)) (#459)
 - Applied a check on result in case of search using Spotify-URL  `--no-metadata` option ([@Amit-L](https://github.com/Amit-L)) (#452)
 - Included a missing `import spotipy` in downloader.py ([@ritiek](https://github.com/ritiek)) (#440)
 

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -38,10 +38,13 @@ def song(input_song, output_song, folder, avconv=False, trim_silence=False):
 
 class Converter:
     def __init__(self, input_song, output_song, folder, delete_original):
+        _, self.input_ext = os.path.splitext(input_song)
+        _, self.output_ext = os.path.splitext(output_song)
+
         self.output_file = os.path.join(folder, output_song)
         rename_to_temp = False
 
-        same_file = input_song == output_song
+        same_file = os.path.abspath(input_song) == os.path.abspath(output_song)
         if same_file:
             # FFmpeg/avconv cannot have the same file for both input and output
             # This would happen when the extensions are same, so rename
@@ -92,26 +95,23 @@ class Converter:
         if not log.level == 10:
             ffmpeg_pre += "-hide_banner -nostats -v panic "
 
-        _, input_ext = os.path.splitext(self.input_file)
-        _, output_ext = os.path.splitext(self.output_file)
-
         ffmpeg_params = ""
 
-        if input_ext == ".m4a":
-            if output_ext == ".mp3":
+        if self.input_ext == ".m4a":
+            if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:v copy -codec:a libmp3lame -ar 44100 "
-            elif output_ext == ".webm":
+            elif self.output_ext == ".webm":
                 ffmpeg_params = "-codec:a libopus -vbr on "
-            elif output_ext == ".m4a":
+            elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
 
-        elif input_ext == ".webm":
-            if output_ext == ".mp3":
+        elif self.input_ext == ".webm":
+            if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:a libmp3lame -ar 44100 "
-            elif output_ext == ".m4a":
+            elif self.output_ext == ".m4a":
                 ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 44100 "
 
-        if output_ext == ".flac":
+        if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 44100 "
 
         # add common params for any of the above combination

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -136,8 +136,6 @@ class Downloader:
             except FileNotFoundError:
                 output_song = self.unconverted_filename(songname)
 
-            if not const.args.input_ext == const.args.output_ext:
-                os.remove(os.path.join(const.args.folder, input_song))
             if not const.args.no_metadata and self.meta_tags is not None:
                 metadata.embed(
                     os.path.join(const.args.folder, output_song), self.meta_tags

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -273,6 +273,9 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
     if parsed.write_m3u and not parsed.list:
         parser.error('--write-m3u can only be used with --list')
 
+    if parsed.avconv and parsed.trim_silence:
+        parser.error("--trim-silence can only be used with FFmpeg")
+
     parsed.log_level = log_leveller(parsed.log_level)
 
     return parsed

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -112,6 +112,7 @@ class TestDownload:
 
 class TestFFmpeg:
     def test_convert_from_webm_to_mp3(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "ffmpeg -y -i {0}.webm -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".webm", filename_fixture + ".mp3", const.args.folder
@@ -119,6 +120,7 @@ class TestFFmpeg:
         assert ' '.join(command) == expect_command
 
     def test_convert_from_webm_to_m4a(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "ffmpeg -y -i {0}.webm -cutoff 20000 -codec:a aac -ar 44100 -b:a 192k -vn {0}.m4a".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".webm", filename_fixture + ".m4a", const.args.folder
@@ -126,6 +128,7 @@ class TestFFmpeg:
         assert ' '.join(command) == expect_command
 
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "ffmpeg -y -i {0}.m4a -codec:v copy -codec:a libmp3lame -ar 44100 -b:a 192k -vn {0}.mp3".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".mp3", const.args.folder
@@ -133,6 +136,7 @@ class TestFFmpeg:
         assert ' '.join(command) == expect_command
 
     def test_convert_from_m4a_to_webm(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "ffmpeg -y -i {0}.m4a -codec:a libopus -vbr on -b:a 192k -vn {0}.webm".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".webm", const.args.folder
@@ -140,6 +144,7 @@ class TestFFmpeg:
         assert ' '.join(command) == expect_command
 
     def test_convert_from_m4a_to_flac(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "ffmpeg -y -i {0}.m4a -codec:a flac -ar 44100 -b:a 192k -vn {0}.flac".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".flac", const.args.folder
@@ -148,7 +153,8 @@ class TestFFmpeg:
 
 
 class TestAvconv:
-    def test_convert_from_m4a_to_mp3(self, filename_fixture):
+    def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):
+        monkeypatch.setattr("os.remove", lambda x: None)
         expect_command = "avconv -loglevel debug -i {0}.m4a -ab 192k {0}.mp3 -y".format(os.path.join(const.args.folder, filename_fixture))
         _, command = convert.song(
             filename_fixture + ".m4a", filename_fixture + ".mp3", const.args.folder, avconv=True

--- a/test/test_download_with_metadata.py
+++ b/test/test_download_with_metadata.py
@@ -151,6 +151,13 @@ class TestFFmpeg:
         )
         assert ' '.join(command) == expect_command
 
+    def test_correct_container_for_m4a(self, filename_fixture, monkeypatch):
+        expect_command = "ffmpeg -y -i {0}.m4a.temp -acodec copy -b:a 192k -vn {0}.m4a".format(os.path.join(const.args.folder, filename_fixture))
+        _, command = convert.song(
+            filename_fixture + ".m4a", filename_fixture + ".m4a", const.args.folder
+        )
+        assert ' '.join(command) == expect_command
+
 
 class TestAvconv:
     def test_convert_from_m4a_to_mp3(self, filename_fixture, monkeypatch):


### PR DESCRIPTION
When input and output filenames are same FFmpeg errors out trying to read and write to the same file.

This PR workarounds by appending ".temp" to the input filename and instead this file now gets passed as the input file. When the conversion is done, this .temp file is then deleted.

Input and output filenames can both be same e.g. when correcting .m4a container as in #453. This was an oversight left by me during the merge of #453. My apologies.

Also closes #458.