### PR TITLE
Use folder argument as base for album/playlist file exports.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Option `-f` (`--folder`) is used when exporting text files using `-p` (`--playlist`) for playlists or `-b` (`--album`) for albums ([@Silverfeelin](https://github.com/Silverfeelin)) (#476)
+
 ## [1.1.1] - 2019-01-03
 ### Added
 - Output informative message in case of no result found in YouTube search ([@Amit-L](https://github.com/Amit-L)) (#452)

--- a/spotdl/spotify_tools.py
+++ b/spotdl/spotify_tools.py
@@ -7,7 +7,9 @@ from titlecase import titlecase
 from logzero import logger as log
 import pprint
 import sys
+import os
 
+from spotdl import const
 from spotdl import internals
 
 
@@ -146,7 +148,8 @@ def write_playlist(playlist_url, text_file=None):
     tracks = playlist["tracks"]
     if not text_file:
         text_file = u"{0}.txt".format(slugify(playlist["name"], ok="-_()[]{}"))
-    return write_tracks(tracks, text_file)
+    filepath = os.path.join(const.args.folder if const.args.folder else "", text_file)
+    return write_tracks(tracks, filepath)
 
 
 def fetch_album(album):
@@ -217,7 +220,8 @@ def write_album(album_url, text_file=None):
     tracks = spotify.album_tracks(album["id"])
     if not text_file:
         text_file = u"{0}.txt".format(slugify(album["name"], ok="-_()[]{}"))
-    return write_tracks(tracks, text_file)
+    filepath = os.path.join(const.args.folder if const.args.folder else "", text_file)
+    return write_tracks(tracks, filepath)
 
 
 def write_tracks(tracks, text_file):


### PR DESCRIPTION
Use `const.args.folder` when using `-b` or `-p`.

**Related**
* https://github.com/ritiek/spotify-downloader/issues/340 Permission Error
* https://github.com/ritiek/spotify-downloader/issues/423 Pass custom filenames when writing playlists, albums, etc. to text files

**Context**
I set up a script that uses an URI handler to call `spotdl`. This allows the application to be called from an URI such as `spotdl:https://open.spotify.com/album/0OkJThJls8FO1lutMzMDJ0`.
https://msdn.microsoft.com/en-us/windows/desktop/aa767914

The problem I faced is that the current working directory for my application is `C:\Windows\System32`, which results in permission issues (https://github.com/ritiek/spotify-downloader/issues/340). The output directory for songs works around this issue, but the same can not currently be said for playlists and albums.

These changes re-use the folder parameter to put the album or playlist text files in the supplied folder. From what I can tell `-f` is already required for both `-p` and `-b` even though the value is ignored.
The global `const` was not included in `spotify_tools.py` but because it was referenced in just about every other script I figured it wouldn't hurt to include it here as well. In particular, `youtube_tools.py` already uses it in the same fashion when downloading songs.

![image](https://user-images.githubusercontent.com/17196309/51088392-4c3e6400-175f-11e9-97ff-a8dd049bb4f4.png)
