### PR TITLE
Write tracks to custom file with `--write-to`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- `--write-to` parameter for setting custom file to write Spotify track URLs to ([@ritiek](https://github.com/ritiek)) (#507)
 - Set custom Spotify Client ID and Client Secret via config.yml ([@ManveerBasra](https://github.com/ManveerBasra)) (#502)
 - Use YouTube as fallback metadata if track not found on Spotify. Also added `--no-fallback-metadata`
   to preserve old behaviour ([@ritiek](https://github.com/ritiek)) (#457)

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -23,6 +23,7 @@ default_conf = {
         "overwrite": "prompt",
         "input-ext": ".m4a",
         "output-ext": ".mp3",
+        "write-to": None,
         "trim-silence": False,
         "download-only-metadata": False,
         "dry-run": False,
@@ -185,6 +186,11 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         help="preferred output format .mp3, .m4a (AAC), .flac, etc.",
     )
     parser.add_argument(
+        "--write-to",
+        default=config["write-to"],
+        help="write tracks from Spotify playlist, album, etc. to this file",
+    )
+    parser.add_argument(
         "-ff",
         "--file-format",
         default=config["file-format"],
@@ -305,6 +311,12 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
 
     if parsed.avconv and parsed.trim_silence:
         parser.error("--trim-silence can only be used with FFmpeg")
+
+    if parsed.write_to and not (parsed.playlist \
+            or parsed.album \
+            or parsed.all_albums \
+            or parsed.username):
+        parser.error("--write-to can only be used with --playlist, --album, --all-albums, or --username")
 
     parsed.log_level = log_leveller(parsed.log_level)
 

--- a/spotdl/spotdl.py
+++ b/spotdl/spotdl.py
@@ -28,7 +28,8 @@ def match_args():
             track_dl.download_single()
     elif const.args.list:
         if const.args.write_m3u:
-            youtube_tools.generate_m3u(track_file=const.args.list)
+            youtube_tools.generate_m3u(track_file=const.args.list,
+                                       text_file=const.args.write_to)
         else:
             list_dl = downloader.ListDownloader(
                 tracks_file=const.args.list,
@@ -37,13 +38,17 @@ def match_args():
             )
             list_dl.download_list()
     elif const.args.playlist:
-        spotify_tools.write_playlist(playlist_url=const.args.playlist)
+        spotify_tools.write_playlist(playlist_url=const.args.playlist,
+                                     text_file=const.args.write_to)
     elif const.args.album:
-        spotify_tools.write_album(album_url=const.args.album)
+        spotify_tools.write_album(album_url=const.args.album,
+                                  text_file=const.args.write_to)
     elif const.args.all_albums:
-        spotify_tools.write_all_albums_from_artist(artist_url=const.args.all_albums)
+        spotify_tools.write_all_albums_from_artist(artist_url=const.args.all_albums,
+                                                   text_file=const.args.write_to)
     elif const.args.username:
-        spotify_tools.write_user_playlist(username=const.args.username)
+        spotify_tools.write_user_playlist(username=const.args.username,
+                                          text_file=const.args.write_to)
 
 
 def main():


### PR DESCRIPTION
This PR adds a new parameter `--write-to` which takes a filename. This argument only works with `--playlist`, `--album`, `--all-albums` and `--user`. Tracks will be written to the file passed in `--write-to` otherwise if this argument is not given, the default behaviour of writing tracks to filename as name of the playlist or album, or etc will persist.