### PR TITLE
Fix YAMLLoadWarning

### DIFF
--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -58,7 +58,7 @@ def merge(default, config):
 def get_config(config_file):
     try:
         with open(config_file, "r") as ymlfile:
-            cfg = yaml.load(ymlfile)
+            cfg = yaml.safe_load(ymlfile)
     except FileNotFoundError:
         log.info("Writing default configuration to {0}:".format(config_file))
         with open(config_file, "w") as ymlfile:


### PR DESCRIPTION
It looks like the latest version of spotdl raises a YAML Load warning and it is suggested to use `yaml.safe_load()` instead of `yaml.load()` to avoid arbitrary code execution via configuration files.