### PR TITLE
Remove duplicate debuglog entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -
 
 ### Changed
+- Removed duplicate debug log entry from `internals.trim_song` ([@ritiek](https://github.com/ritiek)) (#519)
 - Fix YAMLLoadWarning ([@cyberboysumanjay](https://github.com/cyberboysumanjay)) (#517)
 
 ## [1.2.0] - 2019-03-01

--- a/spotdl/internals.py
+++ b/spotdl/internals.py
@@ -51,7 +51,6 @@ def input_link(links):
 
 def trim_song(tracks_file):
     """ Remove the first song from file. """
-    log.debug("Removing downloaded song from tracks file")
     with open(tracks_file, "r") as file_in:
         data = file_in.read().splitlines(True)
     with open(tracks_file, "w") as file_out:


### PR DESCRIPTION
A debug log entry is called twice:

First here:
https://github.com/ritiek/spotify-downloader/blob/e2a136d8854d341720fc3365de72d14f2bef9688/spotdl/downloader.py#L222-L223

And then immediately in `internals.trim_song`:
https://github.com/ritiek/spotify-downloader/blob/e2a136d8854d341720fc3365de72d14f2bef9688/spotdl/internals.py#L52-L54

This PR removes the log entry from `internals.trim_song`.