### PR TITLE
Adds an parameter to disable lyrics.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
--
+- Adds parameter `--no-lyrics`  to disable fetching of lyrics ([@flova](https://github.com/flova)) (#463)
 
 ### Fixed
 -

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -17,6 +17,7 @@ default_conf = {
     "spotify-downloader": {
         "manual": False,
         "no-metadata": False,
+        "no-lyrics": False,
         "no-fallback-metadata": False,
         "avconv": False,
         "folder": internals.get_music_dir(),
@@ -144,6 +145,13 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "--no-metadata",
         default=config["no-metadata"],
         help="do not embed metadata in tracks",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-nl",
+        "--no-lyrics",
+        default=config["no-lyrics"],
+        help="do not embed lyrics",
         action="store_true",
     )
     parser.add_argument(

--- a/spotdl/spotify_tools.py
+++ b/spotdl/spotify_tools.py
@@ -73,13 +73,15 @@ def generate_metadata(raw_song):
     meta_tags[u"publisher"] = album["label"]
     meta_tags[u"total_tracks"] = album["tracks"]["total"]
 
-    log.debug("Fetching lyrics")
-
-    try:
-        meta_tags["lyrics"] = lyricwikia.get_lyrics(
-            meta_tags["artists"][0]["name"], meta_tags["name"]
-        )
-    except lyricwikia.LyricsNotFound:
+    if not const.args.no_lyrics:
+        log.debug("Fetching lyrics")
+        try:
+            meta_tags["lyrics"] = lyricwikia.get_lyrics(
+                meta_tags["artists"][0]["name"], meta_tags["name"]
+            )
+        except lyricwikia.LyricsNotFound:
+            meta_tags["lyrics"] = None
+    else:
         meta_tags["lyrics"] = None
 
     # Some sugar


### PR DESCRIPTION
Hi,
this very small improvement adds a parameter called `--no-lyrics`, which disables the fetching of the lyrics.
In my case, I didn't need the lyrics feature and it caused this strange issue #463 , so it was quite useful to temporarily deactivate it. Another benefit is, that it reduces the download time slightly.
Thank you for this awesome tool by the way.
 