### PR TITLE
feat: add file-format key to use track id as saved filename

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added `--no-remove-original-file` ([@NightMachinary](https://github.com/NightMachinary)) (#580)
+- Added `track_id` key for `--file-format` parameter ([@kadaliao](https://github.com/kadaliao)) (#568)
 
 ### Fixed
 -

--- a/spotdl/internals.py
+++ b/spotdl/internals.py
@@ -30,6 +30,7 @@ formats = {
     9: "track_number",
     10: "total_tracks",
     11: "isrc",
+    12: "track_id",
 }
 
 
@@ -88,6 +89,7 @@ def format_string(string_format, tags, slugification=False, force_spaces=False):
     format_tags[9] = tags["track_number"]
     format_tags[10] = tags["total_tracks"]
     format_tags[11] = tags["external_ids"]["isrc"]
+    format_tags[12] = tags["id"]
 
     format_tags_sanitized = {
         k: sanitize_title(str(v), ok="'-_()[]{}") if slugification else str(v)


### PR DESCRIPTION
<del>add `-k` option to keep `track_id` as name instead of `song_title`</del>

add `track_id` key to `--ff, --file-format` parameter. 