### PR TITLE
Travis CI: Remove sudo and dist lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-dist: xenial
 language: python
-sudo: required
 python:
   - "3.4"
   - "3.5"


### PR DESCRIPTION
Sudo is deprecated in Travis and Xenial is the current default distro