### PR TITLE
Allow for not sorting by the closest duration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `--no-remove-original-file` ([@NightMachinary](https://github.com/NightMachinary)) (#580)
 - Added leading Zeros in `track_number` for correct sorting ([@Dsujan](https://github.com/Dsujan)) (#592)
 - Added `track_id` key for `--file-format` parameter ([@kadaliao](https://github.com/kadaliao)) (#568)
+- Added `--no-duration` ([@timschumi](https://github.com/timschumi)) (#612)
 
 ### Fixed
 - Generate list error --write-m3u ([@arthurlutz](https://github.com/arthurlutz)) (#559)

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -18,6 +18,7 @@ default_conf = {
         "no-remove-original": False,
         "manual": False,
         "no-metadata": False,
+        "no-duration": False,
         "no-fallback-metadata": False,
         "avconv": False,
         "folder": internals.get_music_dir(),
@@ -152,6 +153,12 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "--no-metadata",
         default=config["no-metadata"],
         help="do not embed metadata in tracks",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--no-duration",
+        default=config["no-duration"],
+        help="do not filter tracks by duration",
         action="store_true",
     )
     parser.add_argument(

--- a/spotdl/youtube_tools.py
+++ b/spotdl/youtube_tools.py
@@ -268,6 +268,11 @@ class GenerateYouTubeURL:
                 log.debug(
                     "Since no metadata found on Spotify, going with the first result"
                 )
+            elif const.args.no_duration:
+                result = videos[0]
+                log.debug(
+                    "Filtering by duration is disabled, going with the first result"
+                )
             else:
                 # filter out videos that do not have a similar length to the Spotify song
                 duration_tolerance = 10


### PR DESCRIPTION
The downloader sometimes picks the wrong match because of the filtering by song duration.

Allow the user to overwrite that through a `--no-duration` parameter.