### PR TITLE
Patch all Pafy versions till v0.5.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `track_id` key for `--file-format` parameter ([@kadaliao](https://github.com/kadaliao)) (#568)
 
 ### Fixed
+- Some tracks randomly fail to download with Pafy v0.5.5 ([@ritiek](https://github.com/ritiek)) (#638)
 - Generate list error --write-m3u ([@arthurlutz](https://github.com/arthurlutz)) (#559)
 
 ### Changed

--- a/spotdl/youtube_tools.py
+++ b/spotdl/youtube_tools.py
@@ -16,7 +16,7 @@ pafy.g.opener.addheaders.append(("Range", "bytes=0-"))
 
 # Implement unreleased methods on Pafy object
 # More info: https://github.com/mps-youtube/pafy/pull/211
-if pafy.__version__ <= "0.5.4":
+if pafy.__version__ <= "0.5.5":
     from spotdl import patcher
 
     pafy_patcher = patcher.PatchPafy()


### PR DESCRIPTION
For some reason, the newer release v0.5.5 of Pafy still does not
contain the new methods that were supposed to be a part of the release.
With this commit, we change to also apply patches on v0.5.5.

Addresses #633, #631.