### PR TITLE
Fix KeyError when a track isn't found on Spotify

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed a regression where a track would fail to download if it isn't
+  found on Spotify ([@ritiek](https://github.com/ritiek)) (#653)
 
 ## [1.2.3] - 2019-12-20
 ### Added

--- a/spotdl/internals.py
+++ b/spotdl/internals.py
@@ -93,7 +93,10 @@ def format_string(
     format_tags[9] = tags["track_number"]
     format_tags[10] = tags["total_tracks"]
     format_tags[11] = tags["external_ids"]["isrc"]
-    format_tags[12] = tags["id"]
+    try:
+        format_tags[12] = tags["id"]
+    except KeyError:
+        pass
 
     format_tags_sanitized = {
         k: sanitize_title(str(v), ok="'-_()[]{}") if slugification else str(v)


### PR DESCRIPTION
Ids only exist for Spotify URIs.

Fixes #649.