### PR TITLE
Fix crash when lyrics not yet released on Genius

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
+- Fixed a crash occuring when lyrics for a track are not yet released
+  on Genius ([@ritiek](https://github.com/ritiek)) (#654)
 - Fixed a regression where a track would fail to download if it isn't
   found on Spotify ([@ritiek](https://github.com/ritiek)) (#653)
 

--- a/spotdl/lyrics/providers/genius.py
+++ b/spotdl/lyrics/providers/genius.py
@@ -37,8 +37,10 @@ class Genius(LyricBase):
     def _get_lyrics_text(self, html):
         soup = BeautifulSoup(html, "html.parser")
         lyrics_paragraph = soup.find("p")
-        lyrics = lyrics_paragraph.get_text()
-        return lyrics
+        if lyrics_paragraph:
+            return lyrics_paragraph.get_text()
+        else:
+            raise LyricsNotFound("The lyrics for this track are yet to be released.")
 
     def get_lyrics(self, linesep="\n", timeout=None):
         url = self._guess_lyric_url()


### PR DESCRIPTION
There are some tracks on Genius whose lyrics are yet to be released.
When the tool previously attempted to scrape such webpages, it
resulted in a crash.
The tool will now raise an exception; `LyricNotFoundError` when such a
track is encountered, which is then handled internally by the tool.

Example of one such track on Genius:
https://genius.com/The-federal-empire-good-man-lyrics

Fixes #647.