### PR TITLE
Skip Youtube-API-only fields when scraping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip crash when accessing YouTube-API-only fields in scrape mode ([@ritiek](https://github.com/ritiek)) (#672)
 
 ## [1.2.4] - 2020-01-10
 ### Fixed

--- a/spotdl/youtube_tools.py
+++ b/spotdl/youtube_tools.py
@@ -109,8 +109,8 @@ def generate_metadata(content):
             "artists": [{"name": None}],
             "name": None,
         },
-        "year": content.published.split("-")[0],
-        "release_date": content.published.split(" ")[0],
+        "year": None,
+        "release_date": None,
         "type": "track",
         "disc_number": 1,
         "track_number": 1,
@@ -121,6 +121,14 @@ def generate_metadata(content):
         "copyright": None,
         "genre": None,
     }
+
+    # Workaround for
+    # https://github.com/ritiek/spotify-downloader/issues/671
+    try:
+        meta_tags["year"] = content.published.split("-")[0]
+        meta_tags["release_date"] = content.published.split(" ")[0]
+    except pafy.util.GdataError:
+        pass
 
     return meta_tags
 


### PR DESCRIPTION
This happens because YouTube recently disabled older API keys for some
reason, and so the API key being used internally in Pafy no longer
works.

Fixes #671.