### PR TITLE
Added support for Ogg(opus) and Oga(vorbis). Some minor re-encoding improvement.

### DIFF
--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -117,17 +117,21 @@ class Converter:
 
         if self.input_ext == ".m4a":
             if self.output_ext == ".mp3":
-                ffmpeg_params = "-codec:v copy -codec:a libmp3lame -ar 48000 "
+                ffmpeg_params = "-codec:v copy -codec:a libmp3lame "
             elif self.output_ext == ".webm":
-                ffmpeg_params = "-codec:a libopus -vbr on "
+                ffmpeg_params = "-codec:a libopus -vbr on -ar 48000"
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
-                ffmpeg_params = "-codec:a libmp3lame -ar 48000 "
+                ffmpeg_params = "-codec:a libmp3lame -ar 44000 "
             elif self.output_ext == ".m4a":
-                ffmpeg_params = "-cutoff 20000 -codec:a aac -ar 48000 "
+                ffmpeg_params = "-codec:a aac -ar 44000 "
+            elif self.output_ext == ".ogg":
+                ffmpeg_params = "-codec:a copy "
+            elif self.output_ext == ".oga":
+                ffmpeg_params = "-codec:a libvorbis "
 
         if self.output_ext == ".flac":
             ffmpeg_params = "-codec:a flac -ar 48000 "

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -118,16 +118,18 @@ class Converter:
         if self.input_ext == ".m4a":
             if self.output_ext == ".mp3":
                 ffmpeg_params = "-codec:v copy -codec:a libmp3lame "
-            elif self.output_ext == ".webm":
-                ffmpeg_params = "-codec:a libopus -vbr on -ar 48000"
             elif self.output_ext == ".m4a":
                 ffmpeg_params = "-acodec copy "
+            elif self.output_ext == ".ogg":
+                ffmpeg_params = "-codec:a libopus -vbr on -ar 48000"
+            elif self.output_ext == ".oga":
+                ffmpeg_params = "-codec:a libvorbis -ar 48000"
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
-                ffmpeg_params = "-codec:a libmp3lame -ar 44000 "
+                ffmpeg_params = "-codec:a libmp3lame "
             elif self.output_ext == ".m4a":
-                ffmpeg_params = "-codec:a aac -ar 44000 "
+                ffmpeg_params = "-codec:a aac "
             elif self.output_ext == ".ogg":
                 ffmpeg_params = "-codec:a copy "
             elif self.output_ext == ".oga":

--- a/spotdl/convert.py
+++ b/spotdl/convert.py
@@ -117,9 +117,9 @@ class Converter:
 
         if self.input_ext == ".m4a":
             if self.output_ext == ".mp3":
-                ffmpeg_params = "-codec:v copy -codec:a libmp3lame "
+                ffmpeg_params = "-codec:v copy -codec:a libmp3lame"
             elif self.output_ext == ".m4a":
-                ffmpeg_params = "-acodec copy "
+                ffmpeg_params = "-acodec copy"
             elif self.output_ext == ".ogg":
                 ffmpeg_params = "-codec:a libopus -vbr on -ar 48000"
             elif self.output_ext == ".oga":
@@ -127,19 +127,19 @@ class Converter:
 
         elif self.input_ext == ".webm":
             if self.output_ext == ".mp3":
-                ffmpeg_params = "-codec:a libmp3lame "
+                ffmpeg_params = "-codec:a libmp3lame"
             elif self.output_ext == ".m4a":
-                ffmpeg_params = "-codec:a aac "
+                ffmpeg_params = "-codec:a aac"
             elif self.output_ext == ".ogg":
-                ffmpeg_params = "-codec:a copy "
+                ffmpeg_params = "-codec:a copy"
             elif self.output_ext == ".oga":
-                ffmpeg_params = "-codec:a libvorbis "
+                ffmpeg_params = "-codec:a libvorbis"
 
         if self.output_ext == ".flac":
-            ffmpeg_params = "-codec:a flac -ar 48000 "
+            ffmpeg_params = "-codec:a flac"
 
         # add common params for any of the above combination
-        ffmpeg_params += "-b:a 192k -vn "
+        ffmpeg_params += " -b:a 192k -vn "
         ffmpeg_pre += "-i "
 
         if trim_silence:

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -191,7 +191,7 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         "-o",
         "--output-ext",
         default=config["output-ext"],
-        help="preferred output format .mp3, .m4a (AAC), .flac, etc.",
+        help="preferred output format .mp3, .m4a (AAC), .flac, .ogg (Opus), .oga (Vorbis) etc.",
     )
     parser.add_argument(
         "--write-to",

--- a/spotdl/metadata.py
+++ b/spotdl/metadata.py
@@ -133,29 +133,29 @@ class EmbedMetadata:
     def as_flac_ogg(self):
         music_file = self.music_file
         meta_tags = self.meta_tags
-        if music_file.endswith('.flac'):
+        if music_file.endswith(".flac"):
             audiofile = FLAC(music_file)
-        elif music_file.endswith('.ogg'):
+        elif music_file.endswith(".ogg"):
             audiofile = OggOpus(music_file)
         else:
             audiofile = OggVorbis(music_file)
         
         self._embed_basic_metadata(audiofile)
-        audiofile['year'] = meta_tags['year']
-        audiofile['comment'] = meta_tags['external_urls']['spotify']
-        if meta_tags['lyrics']:
-            audiofile['lyrics'] = meta_tags['lyrics']
+        audiofile["year"] = meta_tags["year"]
+        audiofile["comment"] = meta_tags["external_urls"]["spotify"]
+        if meta_tags["lyrics"]:
+            audiofile["lyrics"] = meta_tags["lyrics"]
             
         image = Picture()
         image.type = 3
-        image.desc = 'Cover'
-        image.mime = 'image/jpeg'
-        albumart = urllib.request.urlopen(meta_tags['album']['images'][0]['url'])
+        image.desc = "Cover"
+        image.mime = "image/jpeg"
+        albumart = urllib.request.urlopen(meta_tags["album"]["images"][0]["url"])
         image.data = albumart.read()
         albumart.close()
         # From the Mutagen docs (https://mutagen.readthedocs.io/en/latest/user/vcomment.html)
         
-        if music_file.endswith('.flac'):
+        if music_file.endswith(".flac"):
             audiofile.add_picture(image)
         else:
             image_data = image.write()

--- a/spotdl/metadata.py
+++ b/spotdl/metadata.py
@@ -145,7 +145,7 @@ class EmbedMetadata:
         audiofile["comment"] = meta_tags["external_urls"]["spotify"]
         if meta_tags["lyrics"]:
             audiofile["lyrics"] = meta_tags["lyrics"]
-            
+
         image = Picture()
         image.type = 3
         image.desc = "Cover"


### PR DESCRIPTION
The other PR by Beewall didn't merge, so I am submitting mine.
didn't need to change much for ogg support.

**about changes in convert.py:**
yt provides different codecs at different sampling rate, no need to change everything to 48khz. if source sampling rate is lower than quality won't improve. like .m4a 128k is sampled at 44khz, you're changing that to 48khz. why? (except for codecs that don't support 44khz like vorbis and opus)
 about cutting of at 20k higher frequency is also not good because though it is true human ear cant hear anything above 20k-25k but cutting of a higher frequency tends to mess with overall audio quality. when playing a file with higher frequency produces a much better output by decoders.
```
m4a 128k 44khz   -->   m4a 128k 44khz
m4a 128k 44khz   -->   mp3 192k 44khz
m4a 128k 44khz   -->   ogg opus 192k 48khz
m4a 128k 44khz   -->   ogg vorbis 192k 48khz

webm ogg 160k 48khz  -->  mp3 192k 48khz
webm ogg 160k 48khz  -->  m4a 192k 48khz
webm ogg 160k 48khz  -->  ogg opus 160k 48khz
webm ogg 160k 48khz  -->  oga vorbis 192k 48khz
```