### PR TITLE
Added missing spotipy import.

### DIFF
--- a/spotdl/helpers/spotify.py
+++ b/spotdl/helpers/spotify.py
@@ -2,6 +2,7 @@ from spotdl.authorize.services import AuthorizeSpotify
 import spotdl.util
 
 import sys
+import spotipy
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
When attempting to downloading a spotify playlist an exception was thrown and during handling it, another exception occurred when trying to check `spotipy.client.SpotifyException` without spotipy being imported. 

Importing spotipy resolved the issue.

Stack trace:
```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/bin/spotdl", line 11, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/spotdl/command_line/__main__.py", line 48, in main
    spotdl.match_arguments()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/spotdl/command_line/core.py", line 82, in match_arguments
    playlist = spotify_tools.fetch_playlist(self.arguments["playlist"])
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/spotdl/helpers/spotify.py", line 60, in fetch_playlist
    except spotify.client.SpotifyException:
NameError: name 'spotify' is not defined
```