### PR TITLE
Fix playlist fetch failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 The release dates mentioned follow the format `DD-MM-YYYY`.
 
 ## [Unreleased]
+### Fixed
+- Skip invalid tracks returned on playlist endpoint with Spotify Web-API
+  ([@ritiek](https://github.com/ritiek/spotify-downloader)) (#732)
 
 ## [2.0.5] - 20-05-2020
 ### Fixed

--- a/spotdl/helpers/spotify.py
+++ b/spotdl/helpers/spotify.py
@@ -134,6 +134,11 @@ class SpotifyHelpers:
                         track = item["track"]
                     else:
                         track = item
+                    # Spotify sometimes returns additional empty "tracks" in the API
+                    # response. We need to discard such "tracks".
+                    # See https://github.com/spotify/web-api/issues/1562
+                    if track is None:
+                        continue
                     try:
                         track_url = track["external_urls"]["spotify"]
                         file_io.write(track_url + "\n")


### PR DESCRIPTION
Skip invalid tracks in Spotify playlist endpoint
    
Spotify sometimes returns additional empty "tracks" in the API
response. We need to discard such "tracks".
    
Fixes #681.