### PR TITLE
Fix crash when applying metadata on YouTube opus

### DIFF
--- a/spotdl/command_line/core.py
+++ b/spotdl/command_line/core.py
@@ -3,6 +3,7 @@ from spotdl.metadata.providers import ProviderYouTube
 from spotdl.metadata.providers import YouTubeSearch
 from spotdl.metadata.embedders import EmbedderDefault
 from spotdl.metadata.exceptions import SpotifyMetadataNotFoundError
+from spotdl.metadata.exceptions import BadMediaFileError
 import spotdl.metadata
 
 from spotdl.lyrics.providers import LyricWikia
@@ -350,7 +351,7 @@ class Spotdl:
         logger.info("Applying metadata")
         try:
             track.apply_metadata(filename, encoding=encoding)
-        except TypeError:
+        except MediaFileError:
             logger.warning("Cannot apply metadata on provided output format.")
 
     def strip_and_filter_duplicates(self, tracks):

--- a/spotdl/metadata/__init__.py
+++ b/spotdl/metadata/__init__.py
@@ -1,6 +1,7 @@
 from spotdl.metadata.provider_base import ProviderBase
 from spotdl.metadata.provider_base import StreamsBase
 
+from spotdl.metadata.exceptions import BadMediaFileError
 from spotdl.metadata.exceptions import MetadataNotFoundError
 from spotdl.metadata.exceptions import SpotifyMetadataNotFoundError
 from spotdl.metadata.exceptions import YouTubeMetadataNotFoundError

--- a/spotdl/metadata/embedders/default_embedder.py
+++ b/spotdl/metadata/embedders/default_embedder.py
@@ -9,6 +9,7 @@ import urllib.request
 import base64
 
 from spotdl.metadata import EmbedderBase
+from spotdl.metadata import BadMediaFileError
 
 import logging
 logger = logging.getLogger(__name__)
@@ -51,7 +52,6 @@ class EmbedderDefault(EmbedderBase):
         self._m4a_tag_preset = M4A_TAG_PRESET
         self._tag_preset = TAG_PRESET
         # self.provider = "spotify" if metadata["spotify_metadata"] else "youtube"
-
     def as_mp3(self, path, metadata, cached_albumart=None):
         """ Embed metadata to MP3 files. """
         logger.debug('Writing MP3 metadata to "{path}".'.format(path=path))
@@ -96,7 +96,6 @@ class EmbedderDefault(EmbedderBase):
             cached_albumart = urllib.request.urlopen(
                 metadata["album"]["images"][0]["url"]
             ).read()
-            albumart.close()
         try:
             audiofile["APIC"] = APIC(
                 encoding=3,
@@ -131,7 +130,6 @@ class EmbedderDefault(EmbedderBase):
                 cached_albumart = urllib.request.urlopen(
                     metadata["album"]["images"][0]["url"]
                 ).read()
-                albumart.close()
             audiofile[M4A_TAG_PRESET["albumart"]] = [
                 MP4Cover(cached_albumart, imageformat=MP4Cover.FORMAT_JPEG)
             ]
@@ -190,7 +188,6 @@ class EmbedderDefault(EmbedderBase):
             cached_albumart = urllib.request.urlopen(
                 metadata["album"]["images"][0]["url"]
             ).read()
-            albumart.close()
         image.data = cached_albumart
 
         if encoding == "flac":

--- a/spotdl/metadata/exceptions.py
+++ b/spotdl/metadata/exceptions.py
@@ -1,3 +1,10 @@
+class BadMediaFileError(Exception):
+    __module__ = Exception.__module__
+
+    def __init__(self, message=None):
+        super().__init__(message)
+
+
 class MetadataNotFoundError(Exception):
     __module__ = Exception.__module__
 

--- a/spotdl/metadata/tests/test_embedder_base.py
+++ b/spotdl/metadata/tests/test_embedder_base.py
@@ -1,4 +1,5 @@
 from spotdl.metadata import EmbedderBase
+from spotdl.metadata import BadMediaFileError
 
 import pytest
 
@@ -35,11 +36,11 @@ class TestMethods:
         assert embedderkid.get_encoding(path) == expect_encoding
 
     def test_apply_metadata_with_explicit_encoding(self, embedderkid):
-        with pytest.raises(TypeError):
+        with pytest.raises(BadMediaFileError):
             embedderkid.apply_metadata("/path/to/music.mp3", {}, cached_albumart="imagedata", encoding="mp3")
 
     def test_apply_metadata_with_implicit_encoding(self, embedderkid):
-        with pytest.raises(TypeError):
+        with pytest.raises(BadMediaFileError):
             embedderkid.apply_metadata("/path/to/music.wav", {}, cached_albumart="imagedata")
 
     class MockHTTPResponse:
@@ -57,7 +58,7 @@ class TestMethods:
     def test_apply_metadata_without_cached_image(self, embedderkid, monkeypatch):
         monkeypatch.setattr("urllib.request.urlopen", self.MockHTTPResponse)
         metadata = {"album": {"images": [{"url": "http://animageurl.com"},]}}
-        with pytest.raises(TypeError):
+        with pytest.raises(BadMediaFileError):
             embedderkid.apply_metadata("/path/to/music.wav", metadata, cached_albumart=None)
 
     @pytest.mark.parametrize("fmt_method_suffix", (

--- a/spotdl/track.py
+++ b/spotdl/track.py
@@ -6,8 +6,12 @@ import sys
 
 from spotdl.encode.encoders import EncoderFFmpeg
 from spotdl.metadata.embedders import EmbedderDefault
+from spotdl.metadata import BadMediaFileError
 
 import spotdl.util
+
+import logging
+logger = logging.getLogger(__name__)
 
 CHUNK_SIZE = 16 * 1024
 
@@ -102,10 +106,15 @@ class Track:
         else:
             albumart = None
 
-        embedder.apply_metadata(
-            input_path,
-            self.metadata,
-            cached_albumart=albumart,
-            encoding=encoding,
-        )
+        try:
+            embedder.apply_metadata(
+                input_path,
+                self.metadata,
+                cached_albumart=albumart,
+                encoding=encoding,
+            )
+        except BadMediaFileError as e:
+            msg = ("{} Such problems should be fixed "
+                  "with FFmpeg set as the encoder.").format(e.args[0])
+            logger.warning(msg)
 


### PR DESCRIPTION
This happens because YouTube encoding has some differences in their
opus format and the traditional opus formatting. Passing such audio
files to FFmpeg should fix such metadata issues.