### PR TITLE
change default search_format

### DIFF
--- a/spotdl/config.py
+++ b/spotdl/config.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIGURATION = {
         "output_ext": "mp3",
         "write_to": None,
         "trim_silence": False,
-        "search_format": "{artist} - {track-name} lyrics",
+        "search_format": "{artist} - {track-name}",
         "dry_run": False,
         "no_spaces": False,
         # "processor": "synchronous",


### PR DESCRIPTION
change default search_format from "{artist} - {track-name} lyrics" to "{artist} - {track-name}"
including "lyrics" has a high chance to mess up youtube search result
reproduce with: spotdl -a https://open.spotify.com/album/4vJlLiY64UWAuVeBl1pzuF
4 out of 6 songs are wrongly matched when using "{artist} - {track-name} lyrics" compared to 0 out of 6 using "{artist} - {track-name}"